### PR TITLE
Fix icon-large styles inside list items

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -58,8 +58,7 @@ li [class*=" icon-"] {
   display: inline-block;
   width: 1.25em;
   text-align: center; }
-li .icon-large:before,
-li .icon-large:before {
+li .icon-large {
   /* 1.5 increased font size for icon-large * 1.25 width */
   width: 1.875em; }
 
@@ -70,8 +69,7 @@ ul.icons {
   ul.icons li [class^="icon-"],
   ul.icons li [class*=" icon-"] {
     width: .8em; }
-  ul.icons li .icon-large:before,
-  ul.icons li .icon-large:before {
+  ul.icons li .icon-large {
     /* 1.5 increased font size for icon-large * 1.25 width */
     vertical-align: initial; }
 

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -3820,8 +3820,7 @@ li [class*=" icon-"] {
   width: 1.25em;
   text-align: center;
 }
-li .icon-large:before,
-li .icon-large:before {
+li .icon-large {
   /* 1.5 increased font size for icon-large * 1.25 width */
 
   width: 1.875em;
@@ -3835,8 +3834,7 @@ ul.icons li [class^="icon-"],
 ul.icons li [class*=" icon-"] {
   width: .8em;
 }
-ul.icons li .icon-large:before,
-ul.icons li .icon-large:before {
+ul.icons li .icon-large {
   /* 1.5 increased font size for icon-large * 1.25 width */
 
   vertical-align: initial;

--- a/docs/assets/less/font-awesome.less
+++ b/docs/assets/less/font-awesome.less
@@ -71,8 +71,7 @@ li {
     width: 1.25em;
     text-align: center;
   }
-  .icon-large:before,
-  .icon-large:before {
+  .icon-large {
     /* 1.5 increased font size for icon-large * 1.25 width */
     width: 1.5*1.25em;
   }
@@ -88,8 +87,7 @@ ul.icons {
     [class*=" icon-"] {
       width: .8em;
     }
-    .icon-large:before,
-    .icon-large:before {
+    .icon-large {
       /* 1.5 increased font size for icon-large * 1.25 width */
       vertical-align: initial;
 //      width: 1.5*1.25em;

--- a/less/font-awesome.less
+++ b/less/font-awesome.less
@@ -71,8 +71,7 @@ li {
     width: 1.25em;
     text-align: center;
   }
-  .icon-large:before,
-  .icon-large:before {
+  .icon-large {
     /* 1.5 increased font size for icon-large * 1.25 width */
     width: 1.5*1.25em;
   }
@@ -88,8 +87,7 @@ ul.icons {
     [class*=" icon-"] {
       width: .8em;
     }
-    .icon-large:before,
-    .icon-large:before {
+    .icon-large {
       /* 1.5 increased font size for icon-large * 1.25 width */
       vertical-align: initial;
 //      width: 1.5*1.25em;

--- a/sass/font-awesome.sass
+++ b/sass/font-awesome.sass
@@ -59,8 +59,7 @@ li
     display: inline-block
     width: 1.25em
     text-align: center
-  .icon-large:before,
-  .icon-large:before
+  .icon-large
     /* 1.5 increased font size for icon-large * 1.25 width
     width: 1.5 * 1.25em
 
@@ -72,8 +71,7 @@ ul.icons
     [class^="icon-"],
     [class*=" icon-"]
       width: .8em
-    .icon-large:before,
-    .icon-large:before
+    .icon-large
       /* 1.5 increased font size for icon-large * 1.25 width
       vertical-align: initial
       //      width: 1.5*1.25em;

--- a/sass/font-awesome.scss
+++ b/sass/font-awesome.scss
@@ -75,8 +75,7 @@ li {
     width: 1.25em;
     text-align: center;
   }
-  .icon-large:before,
-  .icon-large:before {
+  .icon-large {
     /* 1.5 increased font size for icon-large * 1.25 width */
     width: 1.5*1.25em;
   }
@@ -92,8 +91,7 @@ ul.icons {
     [class*=" icon-"] {
       width: .8em;
     }
-    .icon-large:before,
-    .icon-large:before {
+    .icon-large {
       /* 1.5 increased font size for icon-large * 1.25 width */
       vertical-align: initial;
 //      width: 1.5*1.25em;


### PR DESCRIPTION
In Font Awesome 1.0 the LESS declaration was:
.icon-large[class^="icon-"],
.icon-large[class*=" icon-"]

The same declaration in Font Awesome 2.0:
.icon-large:before,
.icon-large:before

Clearly the selector should not be duplicated and should just be:
.icon-large
