### PR TITLE
Restored correct path in compiled css

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -23,8 +23,8 @@
     */
 @font-face {
   font-family: "FontAwesome";
-  src: url('/stylesheets/fonts/../font/fontawesome-webfont.eot');
-  src: url('/stylesheets/fonts/../font/fontawesome-webfont.eot?#iefix') format('eot'), url('/stylesheets/fonts/../font/fontawesome-webfont.woff') format('woff'), url('/stylesheets/fonts/../font/fontawesome-webfont.ttf') format('truetype'), url('/stylesheets/fonts/../font/fontawesome-webfont.otf') format('opentype'), url('/stylesheets/fonts/../font/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: url('../font/fontawesome-webfont.eot');
+  src: url('../font/fontawesome-webfont.eot?#iefix') format('eot'), url('../font/fontawesome-webfont.woff') format('woff'), url('../font/fontawesome-webfont.ttf') format('truetype'), url('../font/fontawesome-webfont.otf') format('opentype'), url('../font/fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal; }
 

--- a/docs/assets/css/font-awesome.css
+++ b/docs/assets/css/font-awesome.css
@@ -24,7 +24,7 @@
 @font-face {
   font-family: 'FontAwesome';
   src: url('../font/fontawesome-webfont.eot');
-  src: url('/stylesheets/fonts/../font/fontawesome-webfont.eot?#iefix') format('eot'), url('/stylesheets/fonts/../font/fontawesome-webfont.woff') format('woff'), url('/stylesheets/fonts/../font/fontawesome-webfont.ttf') format('truetype'), url('/stylesheets/fonts/../font/fontawesome-webfont.otf') format('opentype'), url('/stylesheets/fonts/../font/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: url('../font/fontawesome-webfont.eot?#iefix') format('eot'), url('../font/fontawesome-webfont.woff') format('woff'), url('../font/fontawesome-webfont.ttf') format('truetype'), url('../font/fontawesome-webfont.otf') format('opentype'), url('../font/fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
In the last commit, the path in compiled css files `../font/fontawesome-webfont.*` was changed to `/stylesheets/fonts/../font/fontawesome-webfont.*`.

This commit restores the original path.
I think the change was an accident, please ignore it was intentional.
