### PR TITLE
Add a variable for the root directory to the less files

### DIFF
--- a/less/font-awesome.less
+++ b/less/font-awesome.less
@@ -22,13 +22,15 @@
 
     */
 
+@fontAwesomePath: '../font';
+
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../font/fontawesome-webfont.eot');
-  src: url('../font/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
-    url('../font/fontawesome-webfont.woff') format('woff'),
-    url('../font/fontawesome-webfont.ttf') format('truetype'),
-    url('../font/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: url('@{fontAwesomePath}/fontawesome-webfont.eot');
+  src: url('@{fontAwesomePath}/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
+    url('@{fontAwesomePath}/fontawesome-webfont.woff') format('woff'),
+    url('@{fontAwesomePath}/fontawesome-webfont.ttf') format('truetype'),
+    url('@{fontAwesomePath}/fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This is almost identical to #84, but has a default path set to the current value (`../font`).

Current users won't notice a difference (since it should be essentially the same thing when compiled to CSS), but it allows people using LESS to override the path easily from another file.

In my case, I have a `styles.less` file that imports all of the twitter bootstrap files that I need and `font-awesome.less`. In addition, that file overrides the `@fontAwesomePath` variable to point to the correct path for my application. This provides the benefit of not having to modify any part of Font-Awesome (so it can be used as a submodule).
