### PR TITLE
css: Fixed event handling in Chrome browser

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -31,15 +31,16 @@
 
 /*  Font Awesome styles
     ------------------------------------------------------- */
+[class^="icon-"], [class*=" icon-"] {
+  display: inline-block;
+}
 [class^="icon-"]:before, [class*=" icon-"]:before {
   font-family: FontAwesome;
   font-weight: normal;
   font-style: normal;
-  display: inline-block;
   text-decoration: inherit;
 }
 a [class^="icon-"], a [class*=" icon-"] {
-  display: inline-block;
   text-decoration: inherit;
 }
 /* makes the font 33% larger relative to the icon container */
@@ -53,7 +54,6 @@ a [class^="icon-"], a [class*=" icon-"] {
   line-height: .9em;
 }
 li [class^="icon-"], li [class*=" icon-"] {
-  display: inline-block;
   width: 1.25em;
   text-align: center;
 }


### PR DESCRIPTION
Tested in Chromium 18. Previously hover and click events on <i> elements didn't work properly.
