### PR TITLE
Fixed the "Customize Twitter Bootstrap here" link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -711,7 +711,7 @@
     </div>
     <div class="span9">
       <ol>
-        <li>Customize Twitter Bootstrap <a href="http://twitter.github.com/bootstrap/download.html" target="_blank">here</a>. Make sure to uncheck the default "Icons" under "Base CSS."</li>
+        <li>Customize Twitter Bootstrap <a href="http://twitter.github.com/bootstrap/customize.html" target="_blank">here</a>. Make sure to uncheck the default "Icons" under "Base CSS."</li>
         <li>Copy the Font Awesome font directory into your project.</li>
         <li>Copy font-awesome.css into your project.</li>
         <li>Open your project's font-awesome.css and edit the font url to ensure it points to the right place (see above example).</li>


### PR DESCRIPTION
Fixed the **Customize Twitter Bootstrap here** link: changed from http://twitter.github.com/bootstrap/download.html (was giving a 404) to http://twitter.github.com/bootstrap/customize.html.
