### PR TITLE
Remove space between icon and input element

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -648,16 +648,14 @@
         <div class="control-group">
           <div class="controls">
             <div class="input-prepend">
-              <span class="add-on"><i class="icon-envelope"></i></span>
-              <input class="span2" id="inputIcon" type="text" placeholder="Email address">
+              <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text" placeholder="Email address">
             </div>
           </div>
         </div>
         <div class="control-group">
           <div class="controls">
             <div class="input-prepend">
-              <span class="add-on"><i class="icon-key"></i></span>
-              <input class="span2" id="inputIcon2" type="text" placeholder="Password">
+              <span class="add-on"><i class="icon-key"></i></span><input class="span2" id="inputIcon2" type="text" placeholder="Password">
             </div>
           </div>
         </div>
@@ -930,26 +928,23 @@
     <p>
     <form>
       <div class="input-prepend">
-        <span class="add-on"><i class="icon-envelope"></i></span>
-        <input class="span2" type="text" placeholder="Email address">
+        <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" type="text" placeholder="Email address">
       </div>
       <div class="input-prepend">
-        <span class="add-on"><i class="icon-key"></i></span>
-        <input class="span2" type="password" placeholder="Password">
+        <span class="add-on"><i class="icon-key"></i></span><input class="span2" type="password" placeholder="Password">
       </div>
     </form>
     </p>
   </div>
   <div class="span9">
+    <p>Please note that the span and input tags should be on one line.</p>
 <pre class="prettyprint linenums">
 &lt;form&gt;
   &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;
-    &lt;input class="span2" type="text" placeholder="Email address"&gt;
+    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" type="text" placeholder="Email address"&gt;
   &lt;/div&gt;
   &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-key"&gt;&lt;/i&gt;&lt;/span&gt;
-    &lt;input class="span2" type="password" placeholder="Password"&gt;
+    &lt;span class="add-on"&gt;&lt;i class="icon-key"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" type="password" placeholder="Password"&gt;
   &lt;/div&gt;
 &lt;/form&gt;
 </pre>


### PR DESCRIPTION
There was a space between the icon and the actual input. This was caused by a space in the HTML which I guess was casued by the indentation. There should be no space (so no line break) between the span.add-on and the input tag.
