### PR TITLE
Lowercase oTransitionEnd; fix gh-pages for Opera

### DIFF
--- a/assets/js/tw-bs-201/bootstrap-transition.js
+++ b/assets/js/tw-bs-201/bootstrap-transition.js
@@ -39,7 +39,7 @@
           } else if ( $.browser.mozilla ) {
           	transitionEnd = "transitionend"
           } else if ( $.browser.opera ) {
-          	transitionEnd = "oTransitionEnd"
+          	transitionEnd = "otransitionend"
           }
           return transitionEnd
         }())


### PR DESCRIPTION
Bootstrap had an old bug in it (fixed in latest version), where it had `oTransitionEnd` as the transition event name--unless it is `otransitionend` it won't work with jQuery.

Compare: 

http://miketaylr.github.com/Font-Awesome/#icon/icon-envelope-alt with http://fortawesome.github.com/Font-Awesome/#icon/icon-envelope-alt

The  lightbox fails w/o this fix.

Cheers.
