### PR TITLE
Fixed the space between add-ons and the inputs in the documentation

### DIFF
--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1028,7 +1028,7 @@ select:focus:required:invalid:focus {
   position: relative;
   margin-bottom: 0;
   *margin-left: 0;
-  vertical-align: middle;
+  vertical-align: top;
   -webkit-border-radius: 0 3px 3px 0;
   -moz-border-radius: 0 3px 3px 0;
   border-radius: 0 3px 3px 0;
@@ -1056,7 +1056,7 @@ select:focus:required:invalid:focus {
   line-height: 21px;
   text-align: center;
   text-shadow: 0 1px 0 #ffffff;
-  vertical-align: middle;
+  vertical-align: top;
   background-color: #eeeeee;
   border: 1px solid #ccc;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -648,16 +648,14 @@
         <div class="control-group">
           <div class="controls">
             <div class="input-prepend">
-              <span class="add-on"><i class="icon-envelope"></i></span>
-              <input class="span2" id="inputIcon" type="text" placeholder="Email address">
+              <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" id="inputIcon" type="text" placeholder="Email address">
             </div>
           </div>
         </div>
         <div class="control-group">
           <div class="controls">
             <div class="input-prepend">
-              <span class="add-on"><i class="icon-key"></i></span>
-              <input class="span2" id="inputIcon2" type="text" placeholder="Password">
+              <span class="add-on"><i class="icon-key"></i></span><input class="span2" id="inputIcon2" type="text" placeholder="Password">
             </div>
           </div>
         </div>
@@ -930,12 +928,10 @@
     <p>
     <form>
       <div class="input-prepend">
-        <span class="add-on"><i class="icon-envelope"></i></span>
-        <input class="span2" type="text" placeholder="Email address">
+        <span class="add-on"><i class="icon-envelope"></i></span><input class="span2" type="text" placeholder="Email address">
       </div>
       <div class="input-prepend">
-        <span class="add-on"><i class="icon-key"></i></span>
-        <input class="span2" type="password" placeholder="Password">
+        <span class="add-on"><i class="icon-key"></i></span><input class="span2" type="password" placeholder="Password">
       </div>
     </form>
     </p>
@@ -944,12 +940,10 @@
 <pre class="prettyprint linenums">
 &lt;form&gt;
   &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;
-    &lt;input class="span2" type="text" placeholder="Email address"&gt;
+    &lt;span class="add-on"&gt;&lt;i class="icon-envelope"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" type="text" placeholder="Email address"&gt;
   &lt;/div&gt;
   &lt;div class="input-prepend"&gt;
-    &lt;span class="add-on"&gt;&lt;i class="icon-key"&gt;&lt;/i&gt;&lt;/span&gt;
-    &lt;input class="span2" type="password" placeholder="Password"&gt;
+    &lt;span class="add-on"&gt;&lt;i class="icon-key"&gt;&lt;/i&gt;&lt;/span&gt;&lt;input class="span2" type="password" placeholder="Password"&gt;
   &lt;/div&gt;
 &lt;/form&gt;
 </pre>


### PR DESCRIPTION
I left a comment on the commit about why I did it.

You can see the fix at http://dev.activelink.ca/sandbox/font-awesome/#examples

The doc page was tested in Webkit, Firefox, Opera, and IE8. Works properly in each now.
