### PR TITLE
Update docs to show new @fontAwesomePath variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,15 +685,17 @@
         <li>Copy font-awesome.less into your bootstrap/less directory.</li>
         <li>Open bootstrap.less and replace <code>@import "sprites.less";</code> with <code>@import "font-awesome.less";</code></li>
         <li>
-          Open your project's font-awesome.less and edit the font url to ensure it points to the right place.
+          Open your project's font-awesome.less and edit the <code>@fontAwesomePath</code> variable to ensure it points to the right place.
 <pre class="prettyprint linenums">
+@fontAwesomePath: '../font';
+
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../font/fontawesome-webfont.eot');
-  src: url('../font/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
-     url('../font/fontawesome-webfont.woff') format('woff'),
-     url('../font/fontawesome-webfont.ttf') format('truetype'),
-     url('../font/fontawesome-webfont.svg#FontAwesome') format('svg');
+  src: url('@{fontAwesomePath}/fontawesome-webfont.eot');
+  src: url('@{fontAwesomePath}/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
+    url('@{fontAwesomePath}/fontawesome-webfont.woff') format('woff'),
+    url('@{fontAwesomePath}/fontawesome-webfont.ttf') format('truetype'),
+    url('@{fontAwesomePath}/fontawesome-webfont.svg#FontAwesome') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Docs had outdated sample code where relative path was hard-coded for each URL.
