### PR TITLE
Fixed bug with icon-large math in SCSS version.

### DIFF
--- a/sass/font-awesome.scss
+++ b/sass/font-awesome.scss
@@ -55,7 +55,7 @@ a [class*=" icon-"] {
 /* makes the font 33% larger relative to the icon container */
 .icon-large:before {
   vertical-align: middle;
-  font-size: 4/3em;
+  font-size: #{(4/3)}em;
 }
 
 .btn, .nav-tabs {


### PR DESCRIPTION
This line was not compiling as intended. It would just output `4/3em` directly into the CSS. Using interpolation fixes the issue as noted in #269.
