### PR TITLE
Typo: correct spelling of icon-fighter-jet examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
       <li><i class="icon-beer"></i> icon-beer</li>
       <li><i class="icon-coffee"></i> icon-coffee</li>
       <li><i class="icon-food"></i> icon-food</li>
-      <li><i class="icon-fighter-jet"></i> icon-figher-jet</li>
+      <li><i class="icon-fighter-jet"></i> icon-fighter-jet</li>
     </ul>
   </div>
   <div class="span3">
@@ -360,7 +360,7 @@
       <li><i class="icon-eye-close"></i> icon-eye-close</li>
       <li><i class="icon-eye-open"></i> icon-eye-open</li>
       <li><i class="icon-facetime-video"></i> icon-facetime-video</li>
-      <li><i class="icon-fighter-jet"></i> icon-figher-jet</li>
+      <li><i class="icon-fighter-jet"></i> icon-fighter-jet</li>
       <li><i class="icon-film"></i> icon-film</li>
       <li><i class="icon-filter"></i> icon-filter</li>
       <li><i class="icon-fire"></i> icon-fire</li>


### PR DESCRIPTION
Caught some typos on the icon-fighter-jet examples on the GH pages site.

`icon-figher-jet` -> `icon-fighter-jet`
