### PR TITLE
Update the Sass (scss) file to be more idiomatic and more configurable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@ tmp
 
 src/website/settingslocal.py
 stunnel.log
-
-font-awesome.sass.css

--- a/docs/test.html
+++ b/docs/test.html
@@ -21,8 +21,7 @@
 
   <link rel="stylesheet" href="assets/css/site.css">
   <link rel="stylesheet" href="assets/css/prettify.css">
-  <link rel="stylesheet" href="assets/css/font-awesome.sass.css">
-  <!-- <link rel="stylesheet" href="assets/css/font-awesome.css"> -->
+  <link rel="stylesheet" href="assets/css/font-awesome.css">
   <!--[if IE 7]>
   <link rel="stylesheet" href="assets/css/font-awesome-ie7.min.css">
   <![endif]-->


### PR DESCRIPTION
This PR includes a set of commits that add much more configuration and control to Font Awesome.

On large websites, it's sometimes necessary to be much more careful about what CSS is being compiled, and also have the ability to configure certain aspects of the output. These commits reflect changes I've made when using Font Awesome in large websites over the last few months.

There are now configuration options for most of the features that are not the icon class names themselves. For example, on very large websites and on client work, I do not use Twitter Bootstrap, as these projects always have designers working on the project.

There are also some cases in very large websites where classes beginning with 'icon-' are already being used, and I do not want to target that class at all. Another good example would be the spin animation name, since I've run into cases where a keyframe animated named spin already exists before adding Font Awesome into the project.

One thing I'd like to do after this is add more Sass 3.2 features, particularly silent extends. A feature I have in mind is adding the ability to specify exactly which icon classes are output to CSS, instead of all of them.

Feel free to let me know if there's anything that can be improved here. I do plan on continuing to maintain this fork, since these are all changes I'm using in real projects.

Thanks for all the hard work on Font Awesome.
