### PR TITLE
Update index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -189,7 +189,7 @@
   <div class="row">
     <div class="span4">
       <h4><i class="icon-thumbs-up"></i> Made for Twitter Bootstrap</h4>
-      Designed from scratch to be fully compatible with <a href="http://twitter.github.com/bootstrap/" target="_blank">Twitter Bootstrap 2.2.2</a>.
+      Designed from scratch to be fully compatible with <a href="http://getbootstrap.com" target="_blank">Twitter Bootstrap 2.3.1</a>.
     </div>
     <div class="span4">
       <h4><i class="icon-tint"></i> Designer Friendly</h4>


### PR DESCRIPTION
Updated link to Bootstrap to the Twitter agnostic getbootstrap.com.  @mdo has stated the old twitter.github url will be going away eventually.

Also updated the version of Bootstrap it says FontAwesome was built for, to 2.3.1, just to make it look up-to-date.
