### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
       "url": "http://opensource.org/licenses/mit-license.html"
     }
   ],
-  "dependencies": {
-    "jekyll": "1.0.2",
-    "lessc": "1.3.3"
+  "devDependencies": {
+    "less": "1.3.3"
   }
 }


### PR DESCRIPTION
Removed jekyll because its not a valid npm package and changed lessc to less. Although renamed dependencies to dev-dependencies
