### PR TITLE
Removed jekyll because its not a valid npm package and changed lessc to ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     }
   ],
   "dependencies": {
-    "jekyll": "1.0.2",
-    "lessc": "1.3.3"
+    "less": "1.4.1"
   }
 }


### PR DESCRIPTION
...less. Although renamed dependencies to dev-dependencies

Refers to #1572
