### PR TITLE
Update mixins.less

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -7,9 +7,9 @@
 }
 
 .icon-FontAwesome() {
-  font-family: FontAwesome;
-  font-weight: normal;
-  font-style: normal;
+  font-family: FontAwesome !important;
+  font-weight: normal !important;
+  font-style: normal !important;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
   *margin-right: .3em; // fixes ie7 issues


### PR DESCRIPTION
when we are using font awesome.  Shouldn't we make it harder for the font rules to be overridden by a css rule that comes later?
