### PR TITLE
Restore font-family to :before selector.

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -45,6 +45,7 @@
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
+  font-family: FontAwesome;
   text-decoration: inherit;
   display: inline-block;
   speak: none;


### PR DESCRIPTION
When Font-Awesome is used with other third-party css framework,
like https://github.com/hakimel/reveal.js, said css framework
can define (wrongly or rightly) global rule like
https://github.com/hakimel/reveal.js/blob/master/css/reveal.css#L16
that end up overriding font-awesome.css rules.

And that, even if font-awesome.css is declared _after_ all other css.

Restoring that font-family in the :before selector ensure that rule
is present in the final css rules applied to an html element.

Similar to #1716
