### PR TITLE
Default the icon-prefix

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -3,7 +3,7 @@
 
 $fa-font-path:        "../fonts" !default;
 //$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.0.0/font" !default; // for referencing Bootstrap CDN font files directly
-$fa-css-prefix:       fa;
+$fa-css-prefix:       fa !default;
 $fa-version:          "4.0.0" !default;
 $fa-border-color:     #eee !default;
 $fa-inverse:          #fff !default;


### PR DESCRIPTION
This allows us to override the css-prefix var. Otherwise, could you enlighten us on why you skipped this var's default value?
