### PR TITLE
referenced .min.css file for CDN

### DIFF
--- a/src/get-started.html
+++ b/src/get-started.html
@@ -27,7 +27,7 @@ relative_path: ../
       <li>
         Paste the following code into the <code>&lt;head&gt;</code> section of your site's HTML.
 {% highlight html %}
-<link href="//netdna.bootstrapcdn.com/font-awesome/{{ site.fontawesome.version }}/css/font-awesome.css" rel="stylesheet">
+<link href="//netdna.bootstrapcdn.com/font-awesome/{{ site.fontawesome.version }}/css/font-awesome.min.css" rel="stylesheet">
 {% endhighlight %}
         <p class="alert alert-success"><i class="fa fa-info-circle"></i> Immediately after release, it takes a bit of time for BootstrapCDN to catch up and get the newest version live on their CDN.</p>
       </li>


### PR DESCRIPTION
IMHO the CDN file suggested for copy/paste should be the minified file.  This will help save 3.878kb; just think of all the people who this will benefit:
- those on limited devices & connections (mobile)
- millions of people who have to pay per Mb of downloading
- SEOs whose sites will get-to-glass 0.06 seconds faster, improving ROI
- grateful cat video viewers whose internet pipelines aren't clogged by CSS files
