### PR TITLE
Remove -ms-keyframes

### DIFF
--- a/less/spinning.less
+++ b/less/spinning.less
@@ -20,6 +20,10 @@
   0% { -o-transform: rotate(0deg); }
   100% { -o-transform: rotate(359deg); }
 }
+@-ms-keyframes spin {
+  0% { -ms-transform: rotate(0deg); }
+  100% { -ms-transform: rotate(359deg); }
+}
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(359deg); }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -2,7 +2,7 @@
 // --------------------------
 
 @mixin fa-icon-rotate($degrees, $rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=$rotation);
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: rotate($degrees);
      -moz-transform: rotate($degrees);
       -ms-transform: rotate($degrees);
@@ -11,7 +11,7 @@
 }
 
 @mixin fa-icon-flip($horiz, $vert, $rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=$rotation);
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: scale($horiz, $vert);
      -moz-transform: scale($horiz, $vert);
       -ms-transform: scale($horiz, $vert);

--- a/scss/_spinning.scss
+++ b/scss/_spinning.scss
@@ -20,6 +20,10 @@
   0% { -o-transform: rotate(0deg); }
   100% { -o-transform: rotate(359deg); }
 }
+@-ms-keyframes spin {
+  0% { -ms-transform: rotate(0deg); }
+  100% { -ms-transform: rotate(359deg); }
+}
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(359deg); }

--- a/src/assets/font-awesome/less/spinning.less
+++ b/src/assets/font-awesome/less/spinning.less
@@ -23,10 +23,6 @@
   0% { -o-transform: rotate(0deg); }
   100% { -o-transform: rotate(359deg); }
 }
-@-ms-keyframes spin {
-  0% { -ms-transform: rotate(0deg); }
-  100% { -ms-transform: rotate(359deg); }
-}
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(359deg); }

--- a/src/assets/font-awesome/scss/_spinning.scss
+++ b/src/assets/font-awesome/scss/_spinning.scss
@@ -23,10 +23,6 @@
   0% { -o-transform: rotate(0deg); }
   100% { -o-transform: rotate(359deg); }
 }
-@-ms-keyframes spin {
-  0% { -ms-transform: rotate(0deg); }
-  100% { -ms-transform: rotate(359deg); }
-}
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(359deg); }


### PR DESCRIPTION
Only IE10 supports keyframes and that without the prefix (http://msdn.microsoft.com/en-us/library/ie/hh772747(v=vs.85).aspx). IE9 and lower have no support for keyframes (http://caniuse.com/#search=keyframe).

PR contains deleted -ms-keyframes :-).
