### PR TITLE
SASS will now properly substitute variables in DXImageTransform values.

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -2,7 +2,7 @@
 // --------------------------
 
 @mixin fa-icon-rotate($degrees, $rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=$rotation);
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: rotate($degrees);
      -moz-transform: rotate($degrees);
       -ms-transform: rotate($degrees);
@@ -11,7 +11,7 @@
 }
 
 @mixin fa-icon-flip($horiz, $vert, $rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=$rotation);
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: scale($horiz, $vert);
      -moz-transform: scale($horiz, $vert);
       -ms-transform: scale($horiz, $vert);


### PR DESCRIPTION
SASS doesn't appear to substitute variables in DXImageTransform values normally. This also caused an issue when trying to minify the compiled CSS file, as the file did not have fully valid CSS.

Updating the DXImageTransform values to use SASS interpolation appears to resolve the issue.
