### PR TITLE
Resolves Firefox display bug

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+# Solves Firefox display bug
+<FilesMatch ".(ttf|otf|eot|woff)$">
+	Header set Access-Control-Allow-Origin "*"
+</FilesMatch>


### PR DESCRIPTION
On Firefox, the font doesn't display correctly when included in a project.
Having a specific .htaccess rule into font-awesome include path helps solving the Firefox display bug without having to change .htaccess on sites using this project.
