### PR TITLE
Update mixins vendor prefixes

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -4,17 +4,13 @@
 @mixin fa-icon-rotate($degrees, $rotation) {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: rotate($degrees);
-     -moz-transform: rotate($degrees);
       -ms-transform: rotate($degrees);
-       -o-transform: rotate($degrees);
           transform: rotate($degrees);
 }
 
 @mixin fa-icon-flip($horiz, $vert, $rotation) {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation});
   -webkit-transform: scale($horiz, $vert);
-     -moz-transform: scale($horiz, $vert);
       -ms-transform: scale($horiz, $vert);
-       -o-transform: scale($horiz, $vert);
           transform: scale($horiz, $vert);
 }


### PR DESCRIPTION
Opera 12.10 supports unprefixed CSS animations, gradients, transforms, and transitions or will use -webkit.
Firefox 16.0 supports unprefixed CSS animations, gradients, transforms, and transitions.

Source: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
