### PR TITLE
Update spinning animation vendor prefixes

### DIFF
--- a/scss/_spinning.scss
+++ b/scss/_spinning.scss
@@ -3,23 +3,14 @@
 
 .#{$fa-css-prefix}-spin {
   -webkit-animation: spin 2s infinite linear;
-  -moz-animation: spin 2s infinite linear;
-  -o-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
 }
 
-@-moz-keyframes spin {
-  0% { -moz-transform: rotate(0deg); }
-  100% { -moz-transform: rotate(359deg); }
-}
 @-webkit-keyframes spin {
   0% { -webkit-transform: rotate(0deg); }
   100% { -webkit-transform: rotate(359deg); }
 }
-@-o-keyframes spin {
-  0% { -o-transform: rotate(0deg); }
-  100% { -o-transform: rotate(359deg); }
-}
+
 @keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);


### PR DESCRIPTION
Opera 12.10 supports unprefixed CSS animations, gradients, transforms, and transitions or will use -webkit.
Firefox 16.0 supports unprefixed CSS animations, gradients, transforms, and transitions.

Source: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
