### PR TITLE
Fix empty href for spinning icons example

### DIFF
--- a/src/_includes/icons/spinner.html
+++ b/src/_includes/icons/spinner.html
@@ -6,7 +6,7 @@
       <li>
         <i class="fa fa-info-circle fa-lg fa-li"></i>
         These icons work great with the <code>fa-spin</code> class. Check out the
-        <a href="" class="alert-link">spinning icons example</a>.
+        <a href="{{ page.relative_path }}examples/#spinning" class="alert-link">spinning icons example</a>.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
The link to the spinning icons example has an empty href and links to the current page. Fixing it with the correct URL.
