### PR TITLE
add missing link for spinning icons example

### DIFF
--- a/icons/index.html
+++ b/icons/index.html
@@ -1002,7 +1002,7 @@
       <li>
         <i class="fa fa-info-circle fa-lg fa-li"></i>
         These icons work great with the <code>fa-spin</code> class. Check out the
-        <a href="" class="alert-link">spinning icons example</a>.
+        <a href="../examples/#spinning" class="alert-link">spinning icons example</a>.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
The link to "spinning icons example" was missing on the icons page.
