### PR TITLE
Fix URL in README to use with jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ Build the project and documentation:
 
     $ bundle exec jekyll build
 
-Or serve it on a local server on http://localhost:7998/Font-Awesome/:
+Or serve it on a local server on [http://localhost:7998/Font-Awesome/3.2.1/](http://localhost:7998/Font-Awesome/3.2.1/):
 
     $ bundle exec jekyll serve


### PR DESCRIPTION
The current URL does not work. Also enforced the link destination with a markdown link because the old one was including the colon.

I also noticed that I had to run `npm install less` first. Not sure if that is just my broken local JS environment or the mere fact that I have no idea of all that stuff. ;) Maybe somebody with an actual idea of the JS ecosystem can have a look and decide if this is missing in the docs.
