### PR TITLE
Fixed link of spinning icons example

### DIFF
--- a/src/_includes/icons/spinner.html
+++ b/src/_includes/icons/spinner.html
@@ -6,7 +6,7 @@
       <li>
         <i class="fa fa-info-circle fa-lg fa-li"></i>
         These icons work great with the <code>fa-spin</code> class. Check out the
-        <a href="" class="alert-link">spinning icons example</a>.
+        <a href="../examples/#spinning" class="alert-link">spinning icons example</a>.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/909232/3255865/6e52873e-f210-11e3-851e-ae54b219af25.png)
In the icons page (http://fontawesome.io/icons/). "spinning icons eample" missing the href attribute, so here it is.
