### PR TITLE
fa-spin-reverse

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -83,6 +83,12 @@
   -o-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
 }
+.fa-spin-reverse { 
+  -webkit-animation: spin 2s infinite linear reverse;
+  -moz-animation: spin 2s infinite linear reverse;
+  -o-animation: spin 2s infinite linear reverse;
+  animation: spin 2s infinite linear reverse;
+}
 @-moz-keyframes spin {
   0% {
     -moz-transform: rotate(0deg);


### PR DESCRIPTION
I attempted to use fa-history and then add fa-spin to it. Seemed as if the icon would work but the spin was going in the wrong direction. So I just applied reverse to the fa-spin class animations and it seems to work correctly. The code is not without its problems as it does not seem to work in IE. Here is the code again separately from the file.

.fa-spin-reverse { 
  -webkit-animation: spin 2s infinite linear reverse;
  -moz-animation: spin 2s infinite linear reverse;
  -o-animation: spin 2s infinite linear reverse;
  animation: spin 2s infinite linear reverse;
}
