### PR TITLE
Removed unnecessary usage of the single `fa` class

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -1,7 +1,8 @@
 // Base Class Definition
 // -------------------------
 
-.@{fa-css-prefix} {
+[class^="@{fa-css-prefix}-"],
+[class*=" @{fa-css-prefix}-"] {
   display: inline-block;
   font-family: FontAwesome;
   font-style: normal;


### PR DESCRIPTION
As all icon classes begin with `fa-` we can remove the need to use the single `fa` class.

Before this change you need to define your icons like this:

``` html
<span class="fa fa-glass"></span>
```

With this change, you'll only need to do:

``` html
<span class="fa-glass"></span>
```
