### PR TITLE
Use byebug instead of debugger for ruby 2.x support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 1.0'
-gem 'debugger'
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     blankslate (2.1.2.4)
+    byebug (3.1.2)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
     classifier (1.3.4)
       fast-stemmer (>= 1.0.0)
     colorator (0.1)
     columnize (0.8.9)
     commander (4.1.6)
       highline (~> 1.6.11)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     fast-stemmer (1.0.2)
     ffi (1.9.3)
     highline (1.6.21)
@@ -55,5 +53,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
+  byebug
   jekyll (~> 1.0)

--- a/src/_plugins/icon_page_generator.rb
+++ b/src/_plugins/icon_page_generator.rb
@@ -2,7 +2,7 @@
 # Create individual pages for each icon in the FontAwesome set
 
 require 'yaml'
-require 'debugger'
+require 'byebug'
 
 module Jekyll
 


### PR DESCRIPTION
Hey guys,
`bundle install` will fail on the project with ruby 2.x versions because the debugger gem does not support it.
I recommend using byebug instead.

Have a nice day!
