### PR TITLE
remove reference to bootstrap in getting-started

### DIFF
--- a/src/get-started.html
+++ b/src/get-started.html
@@ -43,7 +43,7 @@ relative_path: ../
 
   <section id="default-css">
     <h2 class="page-header">EASY: Default CSS</h2>
-    <p>Use this method to get the default Font Awesome CSS with the default Bootstrap CSS.</p>
+    <p>Use this method to get the default Font Awesome CSS.</p>
     <ol>
       <li>Copy the entire <code>font-awesome</code> directory into your project.</li>
       <li>


### PR DESCRIPTION
"with the default Bootstrap CSS" makes it sound like Bootstrap is coming with FontAwesome, but they're completely separate.

Trying the Github live editing feature again.
