### PR TITLE
Follow naming conventions for dot-circle-o

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -2687,7 +2687,7 @@ icons:
       - Web Application Icons
       - Directional Icons
 
-  - name:       Dot Circle O
+  - name:       Dot Circle Outlined
     id:         dot-circle-o
     unicode:    f192
     created:    4.0


### PR DESCRIPTION
All other outlined icons have " Outlined" in their name, but not dot-circle-o. This minor edit fixes that.
