### PR TITLE
Animate class for transformed elements

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -23,3 +23,10 @@
       -ms-transform: scale(@horiz, @vert);
           transform: scale(@horiz, @vert);
 }
+
+.fa-icon-transition(@duration: 0.25s, @timing: ease-in-out) {
+  -webkit-transition: transform $duration $timing;
+     -moz-transition: transform $duration $timing;
+       -o-transition: transform $duration $timing;
+          transition: transform $duration $timing;
+}

--- a/less/rotated-flipped.less
+++ b/less/rotated-flipped.less
@@ -8,6 +8,8 @@
 .@{fa-css-prefix}-flip-horizontal { .fa-icon-flip(-1, 1, 0); }
 .@{fa-css-prefix}-flip-vertical   { .fa-icon-flip(1, -1, 2); }
 
+.@{fa-css-prefix}-animate { .fa-icon-transition; }
+
 // Hook for IE8-9
 // -------------------------
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -23,3 +23,10 @@
       -ms-transform: scale($horiz, $vert);
           transform: scale($horiz, $vert);
 }
+
+@mixin fa-icon-transition($duration: 0.25s, $timing: ease-in-out) {
+    -webkit-transition: transform $duration $timing;
+    -moz-transition: transform $duration $timing;
+    -o-transition: transform $duration $timing;
+    transition: transform $duration $timing;
+}

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -25,8 +25,8 @@
 }
 
 @mixin fa-icon-transition($duration: 0.25s, $timing: ease-in-out) {
-    -webkit-transition: transform $duration $timing;
-    -moz-transition: transform $duration $timing;
-    -o-transition: transform $duration $timing;
-    transition: transform $duration $timing;
+  -webkit-transition: transform $duration $timing;
+     -moz-transition: transform $duration $timing;
+       -o-transition: transform $duration $timing;
+          transition: transform $duration $timing;
 }

--- a/scss/_rotated-flipped.scss
+++ b/scss/_rotated-flipped.scss
@@ -8,6 +8,8 @@
 .#{$fa-css-prefix}-flip-horizontal { @include fa-icon-flip(-1, 1, 0); }
 .#{$fa-css-prefix}-flip-vertical   { @include fa-icon-flip(1, -1, 2); }
 
+.#{$fa-css-prefix}-animate { @include fa-icon-transition; }
+
 // Hook for IE8-9
 // -------------------------
 


### PR DESCRIPTION
I've added a mixin called .fa-icon-transition, which handles animation of the transform property. It takes in two arguments, duration and timing. These arguments have default values if none are passed in.

I've also added an animate class to the rotated-flipped include, for lack of a better place to put it. (It seemed to fit best there.) This class simply implements the above-mentioned mixin.