### PR TITLE
Add Less to package.json. Fix package.json formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,17 @@
   "name": "font-awesome",
   "description": "The iconic font and CSS framework",
   "version": "4.2.0",
-  "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
+  "keywords": [
+    "font",
+    "awesome",
+    "fontawesome",
+    "icon",
+    "font",
+    "bootstrap"
+  ],
   "homepage": "http://fontawesome.io/",
   "bugs": {
-    "url" : "http://github.com/FortAwesome/Font-Awesome/issues"
+    "url": "http://github.com/FortAwesome/Font-Awesome/issues"
   },
   "author": {
     "name": "Dave Gandy",
@@ -40,9 +47,11 @@
       "url": "http://opensource.org/licenses/mit-license.html"
     }
   ],
-  "dependencies": {
+  "dependencies": {},
+  "engines": {
+    "node": ">=0.10.3"
   },
-  "engines" : {
-    "node" : ">=0.10.3"
+  "devDependencies": {
+    "less": "~1.4.0"
   }
 }


### PR DESCRIPTION
This is necessary as the [`--yui-compress` option](https://github.com/FortAwesome/Font-Awesome/blob/4.3.0-wip/src/Makefile#L30) was deprecated in `Less@1.5`.

I had issues when building with `jekyll` and it took a while to track this down.. I had a global `lessc` executable on version `2.1.1`.
