### PR TITLE
Fix Jekyll build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
       "url": "http://opensource.org/licenses/mit-license.html"
     }
   ],
-  "dependencies": {
+  "dependencies": {},
+  "engines": {
+    "node": ">=0.10.3"
   },
-  "engines" : {
-    "node" : ">=0.10.3"
+  "devDependencies": {
+    "less": "~2"
   }
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 ---
 ---
-PATH := ../node_modules/.bin:$(PATH)
+LOCAL_LESSC = ../node_modules/.bin/lessc
 
 FA_ROOT_DIRECTORY = assets/font-awesome
 FA_LESS_DIRECTORY = assets/font-awesome/less
@@ -23,11 +23,11 @@ build:
 	@echo "Compiling Less files"
 	@mkdir -p ${FA_CSS_DIRECTORY}
 
-	lessc ${FA_LESS_MODERN} > ${FA_CSS_MODERN}
-	lessc --compress ${FA_LESS_MODERN} > ${FA_CSS_MODERN_MIN}
+	node $(LOCAL_LESSC) ${FA_LESS_MODERN} > ${FA_CSS_MODERN}
+	node $(LOCAL_LESSC) --compress ${FA_LESS_MODERN} > ${FA_CSS_MODERN_MIN}
 #	sass ${FA_SCSS_MODERN} ${FA_CSS_MODERN}
 
-	lessc --yui-compress ${SITE_LESS} > ${SITE_CSS}
+	node $(LOCAL_LESSC) --compress ${SITE_LESS} > ${SITE_CSS}
 	cp -r ${FA_ROOT_DIRECTORY}/* ../
 	mv README.md-nobuild ../README.md
 	cd assets && mv font-awesome font-awesome-{{ site.fontawesome.version }} && zip -r9 font-awesome-{{ site.fontawesome.version }}.zip font-awesome-{{ site.fontawesome.version }} && mv font-awesome-{{ site.fontawesome.version }} font-awesome


### PR DESCRIPTION
Now uses local `lessc` npm binary when building with Jekyll. Also added `less` to package.json.

The `--yui-compress` option was deprecated in `less#1.5`, so now uses `--compress` (is/was there a difference between these two?).