### PR TITLE
Wrap the core styling into a mixin for reusability

### DIFF
--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -1,11 +1,17 @@
 // Base Class Definition
 // -------------------------
 
-.#{$fa-css-prefix} {
+// Include this mixin to turn any element or pseudo-element into an icon.
+@mixin font-awesome-icon() {
   display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome; // shortening font declaration
+  font: normal normal normal #{$fa-font-size-base}/1 FontAwesome; // shortening font declaration
   font-size: inherit; // can't have font-size inherit on line above, so need to override
   text-rendering: auto; // optimizelegibility throws things off #1094
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transform: translate(0, 0); // ensures no half-pixel rendering in firefox
+}
+
+.#{$fa-css-prefix} {
+  @include font-awesome-icon();
 }


### PR DESCRIPTION
It seems better to me to have a mixin for the core styles so that it becomes possible to easily turn other elements into icons (notably pseudo-elements), without having to locally duplicate the styles. This minor change makes that possible by letting people use `@include font-awesome-icon();`.

There is no change to the compiled CSS code. This code works on SassC and Ruby Sass.