### PR TITLE
Wrap the core styling into a mixin for reusability

### DIFF
--- a/less/_core.less
+++ b/less/_core.less
@@ -2,10 +2,5 @@
 // -------------------------
 
 .@{fa-css-prefix} {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome; // shortening font declaration
-  font-size: inherit; // can't have font-size inherit on line above, so need to override
-  text-rendering: auto; // optimizelegibility throws things off #1094
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  .fa-icon();
 }

--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -1,11 +1,16 @@
 // Base Class Definition
 // -------------------------
 
-.#{$fa-css-prefix} {
+// Include this mixin to turn any element or pseudo-element into an icon.
+@mixin font-awesome-icon() {
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome; // shortening font declaration
   font-size: inherit; // can't have font-size inherit on line above, so need to override
   text-rendering: auto; // optimizelegibility throws things off #1094
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.#{$fa-css-prefix} {
+  @include font-awesome-icon();
 }

--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -1,16 +1,6 @@
 // Base Class Definition
 // -------------------------
 
-// Include this mixin to turn any element or pseudo-element into an icon.
-@mixin font-awesome-icon() {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome; // shortening font declaration
-  font-size: inherit; // can't have font-size inherit on line above, so need to override
-  text-rendering: auto; // optimizelegibility throws things off #1094
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 .#{$fa-css-prefix} {
-  @include font-awesome-icon();
+  @include fa-icon();
 }


### PR DESCRIPTION
This modification creates a mixin for the core styles so that it becomes possible to easily turn other elements into icons without having to locally duplicate the styles. This is particularly useful when working with pseudo-elements. People would be able to simply use `@include font-awesome-icon();` in any element.

I compiled the modified version and the original version, and there is no difference in the output.