### PR TITLE
allow searching "cancel" for "ban" icon

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -971,6 +971,7 @@ icons:
       - block
       - stop
       - abort
+      - cancel
     categories:
       - Web Application Icons
 


### PR DESCRIPTION
It's the most relevant icon for "cancel" in the iconset. (same patch as #5572, but on 4.3.1-wip branch).