### PR TITLE
Add woff2 to component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -15,6 +15,7 @@
     "fonts/fontawesome-webfont.svg",
     "fonts/fontawesome-webfont.ttf",
     "fonts/fontawesome-webfont.woff",
+    "fonts/fontawesome-webfont.woff2",
     "fonts/FontAwesome.otf"
   ]
 }


### PR DESCRIPTION
Recently added woff2 file was not added to component.json.  Was causing issues when using services like rails-assets.org.