### PR TITLE
Add instructions for sending PR for icon keyword addition/removal suggestions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,16 @@ New icons mostly start as requests by the [Font Awesome community on GitHub](../
   - Attach a single color image or two that represent the idea you're going for.
   - Request concrete objects: it's harder to make an icon to represent happiness, it's easier to make a smiley face. ☺
 
+## Suggesting icon keyword addition/removal
 
+Icon filters are maintained by the [Font Awesome community on GitHub](../../pulls?q=is%3Apr+label%3Adoc).
+
+If you feel that an icon
+
+* is missing keyword(s)
+* contains invalid keyword(s)
+
+please send a [PR](https://help.github.com/articles/using-pull-requests/) to the `master` branch.
 
 ## Reporting issues
 

--- a/src/_includes/icons/filter.html
+++ b/src/_includes/icons/filter.html
@@ -24,7 +24,7 @@
   </div>
   <div id="no-search-results">
     <div class="alert alert-warning" role="alert"><i class="fa fa-warning margin-right-sm"></i>No icons matching <strong>'<span></span>'</strong> were found.</div>
-    <div class="alert alert-info" role="alert"><i class="fa fa-exclamation-circle margin-right-sm"></i>Tags are added by the community. Do you think your search query should return an icon? Send a pull request on <a href="https://github.com/FortAwesome/Font-Awesome">GitHub</a>!</div>
   </div>
+  <div class="alert alert-info" role="alert"><i class="fa fa-exclamation-circle margin-right-sm"></i>Tags are added by the community. Do you think your search query should return an icon? Send a pull request on <a href="https://github.com/FortAwesome/Font-Awesome/blob/master/CONTRIBUTING.md#suggesting-icon-keyword-additionremoval">GitHub</a>!</div>
 
 </section>


### PR DESCRIPTION
Noticed that PRs concerning icon filters are often done in the wrong branch. This should clear things up.

Might be of interest to label said PRs with its own label, e.g. `filter`, to be able to exclusively reference them at [CONTRIBUTING.md#23](https://github.com/williamboman/Font-Awesome/commit/2d04b5d059da19f0b9a3e974008ae594ffa530f5#diff-6a3371457528722a734f3c51d9238c13R23)

Live demo [here](https://github.com/williamboman/Font-Awesome/blob/4.3.1-wip/CONTRIBUTING.md#suggesting-icon-keyword-additionremoval)