### PR TITLE
Added version indicators for new icons to cheatsheet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ icon_destination: icon         # Relative to destination
 fontawesome:
   version:        4.3.0
   minor_version:  4.3
+  major_version:  4
   doc_blob:       v4.3.0
   url:            http://fontawesome.io
   legacy_url:     http://fortawesome.github.com/Font-Awesome/

--- a/src/cheatsheet.html
+++ b/src/cheatsheet.html
@@ -24,10 +24,11 @@ relative_path: ../
 
     {% for icon in sorted_icons %}
     <div class="col-md-4 col-sm-6 col-lg-3">
+      {% if icon.created >= site.fontawesome.major_version %}<small class="text-muted pull-right">{{ icon.created }}</small>{% endif %}
       <i class="fa fa-fw">&#x{{ icon.unicode }}</i>
       fa-{{ icon.class }}
       {% if icon.alias_of %} <span class="text-muted">(alias)</span>{% endif %}
-      <span class="muted">[&amp;#x{{ icon.unicode }};]</span>
+      <span class="text-muted">[&amp;#x{{ icon.unicode }};]</span>
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
If an icon is newer than the current major version, show a version badge
to indicate which version of FontAwesome this icon was added.

See #4234
Closes #4230

/cc @tagliala 