### PR TITLE
Fix link to spinning examples href to be #animated instead of #spinning

### DIFF
--- a/icons/index.html
+++ b/icons/index.html
@@ -3720,7 +3720,7 @@
       <li>
         <i class="fa fa-info-circle fa-lg fa-li"></i>
         These icons work great with the <code>fa-spin</code> class. Check out the
-        <a href="../examples/#spinning" class="alert-link">spinning icons example</a>.
+        <a href="../examples/#animated" class="alert-link">spinning icons example</a>.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
`#spinning` doesn't exist currently in the examples page, however `#animated` does.