### PR TITLE
Fix link to spinning examples href to be #animated instead of #spinning

### DIFF
--- a/src/_includes/icons/spinner.html
+++ b/src/_includes/icons/spinner.html
@@ -6,7 +6,7 @@
       <li>
         <i class="fa fa-info-circle fa-lg fa-li"></i>
         These icons work great with the <code>fa-spin</code> class. Check out the
-        <a href="{{ page.relative_path }}examples/#spinning" class="alert-link">spinning icons example</a>.
+        <a href="{{ page.relative_path }}examples/#animated" class="alert-link">spinning icons example</a>.
       </li>
     </ul>
   </div>


### PR DESCRIPTION
`#spinning` doesn't exist currently in the examples page, however `#animated` does.