### PR TITLE
Add style attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "font-awesome",
   "description": "The iconic font and CSS framework",
   "version": "4.3.1",
+  "style": "css/font-awesome.css",
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
We built a tool called [Dr Frankenstyle](https://github.com/pivotal-cf/dr-frankenstyle), which crawls npm packages a user has installed and extracts the CSS files referenced by the `style` attribute in the `package.json`.

We would like to use Dr Frankenstyle with Font-Awesome, but we noticed that your `package.json` doesn't have the `style` attribute. 

This PR adds the style attribute (similar to what you already have in your `component.json` file). We expect it is a fairly minor change, but we hoped to get your feedback.

Thanks!
Vinson & @stubbornella 