### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,7 @@
       "web": "http://twitter.com/supercodepoet"
     }
   ],
-  "licenses": [
-    {
-      "type": "OFL-1.1",
-      "url": "http://scripts.sil.org/OFL"
-    },
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/mit-license.html"
-    }
-  ],
+  "license": "OFL-1.1 AND MIT",
   "dependencies": {
   },
   "engines" : {


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/