### PR TITLE
Add 'collapse' and 'contract' filter terms for 'compress' icon

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -1037,7 +1037,9 @@ icons:
     unicode:    f066
     created:    1.0
     filter:
+      - collapse
       - combine
+      - contract
       - merge
       - smaller
     categories:


### PR DESCRIPTION
Found the 'fa-expand' icon easily enough, but it was difficult to find its inverse 'fa-compress.'  Adding 'collapse' and 'contract' antonyms to make 'fa-compress' more discoverable from the 'expand' icon.

This should be a docs-only change, but I was unclear on whether it should be submitted against `master` or the latest WIP branch, so I'm doing the latter which seems to be the more general solution.  Please let me know if I should resubmit against `master`.  Thanks!