### PR TITLE
Add a link to Cheatsheet in the primary navbar.

### DIFF
--- a/src/_includes/navbar.html
+++ b/src/_includes/navbar.html
@@ -77,6 +77,7 @@
           </ul>
         </li>
         <li{% if page.navbar_active == "community" %} class="active"{% endif %}><a href="{{ page.relative_path }}community/">Community</a></li>
+        <li{% if page.navbar_active == "cheatsheet" %} class="active"{% endif %}><a href="{{ page.relative_path }}cheatsheet/">Cheatsheet</a></li>
         <li{% if page.navbar_active == "license" %} class="active"{% endif %}><a href="{{ page.relative_path }}license/">License</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
I use fontawesome cheatsheet very frequently. Instead of appending <code>/cheatsheet</code> to the home url each time, I thought that it would be a good idea to have it in the navbar as one of the menu items.
