### PR TITLE
Replaced protocol-relative URL with HTTPS protocol

### DIFF
--- a/src/get-started.html
+++ b/src/get-started.html
@@ -27,7 +27,7 @@ relative_path: ../
       <li>
         Paste the following code into the <code>&lt;head&gt;</code> section of your site's HTML.
 {% highlight html %}
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/{{ site.fontawesome.version }}/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/{{ site.fontawesome.version }}/css/font-awesome.min.css">
 {% endhighlight %}
         <p class="alert alert-success"><i class="fa fa-info-circle"></i> Immediately after release, it takes a bit of time for BootstrapCDN to catch up and get the newest version live on their CDN.</p>
       </li>


### PR DESCRIPTION
It is no longer considered good practice to use protocol-relative URLs (http://www.paulirish.com/2010/the-protocol-relative-url/). So the CDN request should be made via HTTPs. I've updated the documentation accordingly.