### PR TITLE
Add filter to `fa-phone`

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -1523,6 +1523,7 @@ icons:
        - voice
        - number
        - support
+       - earphone
     categories:
       - Web Application Icons
 


### PR DESCRIPTION
Glyphicon's corresponding icon for `fa-phone` is `glyphicon-earphone`.

This should maybe be an alias though (saw #1805).