### PR TITLE
Add a line to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
   "license": ["OFL-1.1", "MIT", "CC-BY-3.0"],
   "main": [
     "less/font-awesome.less",
-    "scss/font-awesome.scss"
+    "scss/font-awesome.scss",
+    "css/font-awesome.css"
   ],
   "ignore": [
     "*/.*",


### PR DESCRIPTION
Add a line to bower.json to be able to inject de css dependency to the project when it is installed via bower.

I really don't know if it's a mistake of you or the new version is that way. If yes you could explain to me why.

Thanks.