### PR TITLE
Allow easy use with bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "The iconic font and CSS framework",
   "version": "4.4.0",
   "style": "css/font-awesome.css",
+  "main": "css/font-awesome.css",
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
With this new entry in package.json, you can require the font-awesome library easily in bundlers tools like webpack because it resolves directly to the correct file ( like normalize.css do )
