### PR TITLE
Remove warnings on safari

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -118,31 +118,31 @@
   }
 }
 .fa-rotate-90 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 .fa-rotate-180 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 .fa-rotate-270 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 .fa-flip-horizontal {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
   -webkit-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
   -webkit-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   transform: scale(1, -1);

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -12,14 +12,14 @@
 }
 
 .fa-icon-rotate(@degrees, @rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation)";
   -webkit-transform: rotate(@degrees);
       -ms-transform: rotate(@degrees);
           transform: rotate(@degrees);
 }
 
 .fa-icon-flip(@horiz, @vert, @rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation, mirror=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation, mirror=1)";
   -webkit-transform: scale(@horiz, @vert);
       -ms-transform: scale(@horiz, @vert);
           transform: scale(@horiz, @vert);

--- a/src/3.2.1/assets/font-awesome/less/extras.less
+++ b/src/3.2.1/assets/font-awesome/less/extras.less
@@ -48,7 +48,7 @@ a .icon-spin {
   -ms-transform: rotate(90deg);
   -o-transform: rotate(90deg);
   transform: rotate(90deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
 }
 
 .icon-rotate-180:before {
@@ -57,7 +57,7 @@ a .icon-spin {
   -ms-transform: rotate(180deg);
   -o-transform: rotate(180deg);
   transform: rotate(180deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
 }
 
 .icon-rotate-270:before {
@@ -66,7 +66,7 @@ a .icon-spin {
   -ms-transform: rotate(270deg);
   -o-transform: rotate(270deg);
   transform: rotate(270deg);
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
 }
 
 .icon-flip-horizontal:before {

--- a/src/assets/font-awesome/less/mixins.less
+++ b/src/assets/font-awesome/less/mixins.less
@@ -8,14 +8,14 @@
 }
 
 .fa-icon-rotate(@degrees, @rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation)";
   -webkit-transform: rotate(@degrees);
       -ms-transform: rotate(@degrees);
           transform: rotate(@degrees);
 }
 
 .fa-icon-flip(@horiz, @vert, @rotation) {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation, mirror=1);
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation, mirror=1)";
   -webkit-transform: scale(@horiz, @vert);
       -ms-transform: scale(@horiz, @vert);
           transform: scale(@horiz, @vert);


### PR DESCRIPTION
Safari throws warnings on filter: property which is set for IE. Putting them in quotes removes the warning and leaves it working for IE
