### PR TITLE
Allow getting paths from node for build process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+var path = require('path');
+var entryPoint = require.resolve('font-awesome');
+
+var faDir = path.dirname(entryPoint);
+
+var sassDir = path.join(faDir, 'scss');
+var lessDir = path.join(faDir, 'less');
+var  cssDir = path.join(faDir, 'css');
+var fontDir = path.join(faDir, 'fonts', '*');
+
+function includePaths() {
+  return {
+    scss:  sassDir,
+    less:  sassDir,
+    css:   cssDir,
+    fonts: fontDir
+  }
+}
+
+module.exports = {
+
+  scssPath: includePaths().scss,
+  lessPath: includePaths().less,
+  cssPath: includePaths().css,
+  
+  fontPath: includePaths().fonts,
+
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The iconic font and CSS framework",
   "version": "4.4.0",
   "style": "css/font-awesome.css",
-  "main": "index.js"
+  "main": "index.js",
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "The iconic font and CSS framework",
   "version": "4.4.0",
   "style": "css/font-awesome.css",
+  "main": "index.js"
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
This allows things like:

``` javascript
gulp.task('sass', function () {
  gulp.src('./sass/main.scss')
    .pipe(sass({
      includePaths: [require('font-awesome').scssPath]
    }))
    .pipe(gulp.dest('./build/css'));
});

gulp.task('fonts', function() {
  gulp.src(require('font-awesome').fontPath)
    .pipe(gulp.dest('./build/fonts'));
});
```

Note I only tested this for sass and fonts but added the css and less paths as well.
