### PR TITLE
BUGFIX #7753: font-awesome.css missing in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
   "license": ["OFL-1.1", "MIT", "CC-BY-3.0"],
   "main": [
     "less/font-awesome.less",
-    "scss/font-awesome.scss"
+    "scss/font-awesome.scss",
+    "css/font-awesome.css"
   ],
   "ignore": [
     "*/.*",


### PR DESCRIPTION
`Gulp` `main-bower-files` css file injection issue.