### PR TITLE
Docs, Examples: fixed old icon-* to fa-*

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -442,7 +442,7 @@ current, borne back ceaselessly into the past.
 <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">&quot;fa fa-shield fa-rotate-180&quot;</span><span class="nt">&gt;&lt;/i&gt;</span> fa-rotate-180<span class="nt">&lt;br&gt;</span>
 <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">&quot;fa fa-shield fa-rotate-270&quot;</span><span class="nt">&gt;&lt;/i&gt;</span> fa-rotate-270<span class="nt">&lt;br&gt;</span>
 <span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">&quot;fa fa-shield fa-flip-horizontal&quot;</span><span class="nt">&gt;&lt;/i&gt;</span> fa-flip-horizontal<span class="nt">&lt;br&gt;</span>
-<span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">&quot;fa fa-shield fa-flip-vertical&quot;</span><span class="nt">&gt;&lt;/i&gt;</span> icon-flip-vertical
+<span class="nt">&lt;i</span> <span class="na">class=</span><span class="s">&quot;fa fa-shield fa-flip-vertical&quot;</span><span class="nt">&gt;&lt;/i&gt;</span> fa-flip-vertical
 </code></pre></div>
     </div>
   </div>


### PR DESCRIPTION
I spotted this very small mistake while checking out the examples page. It must have been carried on from version 3. This PR fixes it.

Page: https://fortawesome.github.io/Font-Awesome/examples/