### PR TITLE
Docs, Examples: fixed old icon-* to fa-*

### DIFF
--- a/src/_includes/examples/rotated-flipped.html
+++ b/src/_includes/examples/rotated-flipped.html
@@ -27,7 +27,7 @@
 <i class="fa fa-shield fa-rotate-180"></i> fa-rotate-180<br>
 <i class="fa fa-shield fa-rotate-270"></i> fa-rotate-270<br>
 <i class="fa fa-shield fa-flip-horizontal"></i> fa-flip-horizontal<br>
-<i class="fa fa-shield fa-flip-vertical"></i> icon-flip-vertical
+<i class="fa fa-shield fa-flip-vertical"></i> fa-flip-vertical
 {% endhighlight %}
     </div>
   </div>


### PR DESCRIPTION
I spotted this very small mistake while checking out the examples page. It must have been carried on from version 3. This PR fixes it.

Page: https://fortawesome.github.io/Font-Awesome/examples/

-- Was #7808 but this time the file is the right one hopefully.