### PR TITLE
Added space after # in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-#[Font Awesome v4.5.0](http://fontawesome.io)
-###The iconic font and CSS framework
+# [Font Awesome v4.5.0](http://fontawesome.io)
+### The iconic font and CSS framework
 
 Font Awesome is a full suite of 605 pictographic icons for easy scalable vector graphics on websites,
 created and maintained by [Dave Gandy](http://twitter.com/davegandy).
@@ -8,7 +8,7 @@ Stay up to date with the latest release and announcements on Twitter:
 
 Get started at http://fontawesome.io!
 
-##License
+## License
 - The Font Awesome font is licensed under the SIL OFL 1.1:
   - http://scripts.sil.org/OFL
 - Font Awesome CSS, LESS, and Sass files are licensed under the MIT License:
@@ -19,7 +19,7 @@ Get started at http://fontawesome.io!
   - `Font Awesome by Dave Gandy - http://fontawesome.io`
 - Full details: http://fontawesome.io/license
 
-##Changelog
+## Changelog
 - [v4.5.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.5.0+is%3Aclosed)
 - [v4.4.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.4.0+is%3Aclosed)
 - [v4.3.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.3.0+is%3Aclosed)
@@ -42,7 +42,7 @@ Get started at http://fontawesome.io!
 Please read through our [contributing guidelines](https://github.com/FortAwesome/Font-Awesome/blob/master/CONTRIBUTING.md).
 Included are directions for opening issues, coding standards, and notes on development.
 
-##Versioning
+## Versioning
 
 Font Awesome will be maintained under the Semantic Versioning guidelines as much as possible. Releases will be numbered
 with the following format:
@@ -57,12 +57,12 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org.
 
-##Author
+## Author
 - Email: dave@fontawesome.io
 - Twitter: http://twitter.com/davegandy
 - GitHub: https://github.com/davegandy
 
-##Component
+## Component
 To include as a [component](http://github.com/component/component), just run
 
     $ component install FortAwesome/Font-Awesome

--- a/src/README.md-nobuild
+++ b/src/README.md-nobuild
@@ -1,7 +1,7 @@
 ---
 ---
-#[Font Awesome v{{ site.fontawesome.version }}]({{ site.fontawesome.url }})
-###The iconic font and CSS framework
+# [Font Awesome v{{ site.fontawesome.version }}]({{ site.fontawesome.url }})
+### The iconic font and CSS framework
 
 Font Awesome is a full suite of {{ icons | size }} pictographic icons for easy scalable vector graphics on websites,
 created and maintained by [{{ site.fontawesome.author.name }}](http://twitter.com/{{ site.fontawesome.author.twitter }}).
@@ -10,7 +10,7 @@ Stay up to date with the latest release and announcements on Twitter:
 
 Get started at {{ site.fontawesome.url }}!
 
-##License
+## License
 - The Font Awesome font is licensed under the SIL OFL 1.1:
   - http://scripts.sil.org/OFL
 - Font Awesome CSS, LESS, and Sass files are licensed under the MIT License:
@@ -21,7 +21,7 @@ Get started at {{ site.fontawesome.url }}!
   - `Font Awesome by Dave Gandy - http://fontawesome.io`
 - Full details: http://fontawesome.io/license
 
-##Changelog
+## Changelog
 - [v4.5.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.5.0+is%3Aclosed)
 - [v4.4.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.4.0+is%3Aclosed)
 - [v4.3.0 GitHub milestones](https://github.com/FortAwesome/Font-Awesome/issues?q=milestone%3A4.3.0+is%3Aclosed)
@@ -44,7 +44,7 @@ Get started at {{ site.fontawesome.url }}!
 Please read through our [contributing guidelines](https://github.com/FortAwesome/Font-Awesome/blob/master/CONTRIBUTING.md).
 Included are directions for opening issues, coding standards, and notes on development.
 
-##Versioning
+## Versioning
 
 Font Awesome will be maintained under the Semantic Versioning guidelines as much as possible. Releases will be numbered
 with the following format:
@@ -59,12 +59,12 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org.
 
-##Author
+## Author
 - Email: {{ site.fontawesome.author.email }}
 - Twitter: http://twitter.com/{{ site.fontawesome.author.twitter }}
 - GitHub: https://github.com/{{ site.fontawesome.author.github }}
 
-##Component
+## Component
 To include as a [component](http://github.com/component/component), just run
 
     $ component install FortAwesome/Font-Awesome


### PR DESCRIPTION
Added space after # in README.md for consistency and proper appearance on npmjs.com project page.

It seems that **npmjs.com** requires a space after # to properly generate **heading** tag.

Also in **CONTRIBUTE.md** there is a space after so this also adds to consistency.