### PR TITLE
Correct spelling ('sumarily' should be 'summarily').

### DIFF
--- a/src/3.2.1/community/index.html
+++ b/src/3.2.1/community/index.html
@@ -256,7 +256,7 @@
   Found a way to solve a bug in Font Awesome? Want to contribute new features? Here are a few things to remember:
   <ol>
     <li>Please submit all pull requests against *-wip branches.</li>
-    <li>All pull requests submitted against master will be sumarily closed and this guide referenced.</li>
+    <li>All pull requests submitted against master will be summarily closed and this guide referenced.</li>
     <li>
       After doing everything above, feel free to
       <a href="https://github.com/FortAwesome/Font-Awesome/issues/new">submit a pull request</a>.

--- a/src/_includes/community/submitting-pull-requests.html
+++ b/src/_includes/community/submitting-pull-requests.html
@@ -4,7 +4,7 @@
   <ol>
     <li>Please do not submit new icons.</li>
     <li>Please submit all pull requests against *-wip branches.</li>
-    <li>All pull requests submitted against master will be sumarily closed and this guide referenced.</li>
+    <li>All pull requests submitted against master will be summarily closed and this guide referenced.</li>
     <li>
       After doing everything above, feel free to
       <a href="{{ site.fontawesome.github.url }}/issues/new">submit a pull request</a>.


### PR DESCRIPTION
See http://dictionary.reference.com/browse/summarily.

I've submitted this pull-request to the master branch as the change only affects the documentation.