### PR TITLE
Updated bower.json to have css as main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   "devDependencies": {},
   "license": ["OFL-1.1", "MIT", "CC-BY-3.0"],
   "main": [
+    "css/font-awesome.css",
     "less/font-awesome.less",
     "scss/font-awesome.scss"
   ],


### PR DESCRIPTION
for those who still using css and not moved to scss and less. 

Grunt was removing css/font-awesome.css because of this.