### PR TITLE
update jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,9 @@ url:              http://localhost:7998
 
 source:           src
 destination:      _gh_pages
-plugins:          src/_plugins
+plugins_dir:      src/_plugins
 
-pygments:         true
+highlighter:      pygments
 permalink:        pretty
 
 # ensures SCSS files are compiled


### PR DESCRIPTION
```
Deprecation: The 'plugins' configurationoption has been renamed to 'plugins_dir'. Please update your config file accordingly.
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```