### PR TITLE
Remove Font Awesome Feedback Survey

### DIFF
--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -5,25 +5,25 @@ $(function () {
     {
       quote: "Take your icon game to the next level. Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
       class: "fort-awesome",
-      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_1_next_level&utm_campaign=promo_4.4_update",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_1_next_level&utm_campaign=promo_4.5_update",
       btn_text: "Gimme Some!"
     },
     {
       quote: "Make your icons load 10x faster! Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
       class: "fort-awesome",
-      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_3_faster_loading&utm_campaign=promo_4.4_update",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_3_faster_loading&utm_campaign=promo_4.5_update",
       btn_text: "Gimme Some!"
     },
     {
       quote: "Looking for other great icon sets? Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
       class: "fort-awesome",
-      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_4_more_icons&utm_campaign=promo_4.4_update",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_4_more_icons&utm_campaign=promo_4.5_update",
       btn_text: "Gimme Some!"
     },
     {
       quote: "Want to add your own icon? Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
       class: "fort-awesome",
-      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_your_own_icon&utm_campaign=promo_4.4_update",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_your_own_icon&utm_campaign=promo_4.5_update",
       btn_text: "Gimme Some!"
     },
 
@@ -31,25 +31,25 @@ $(function () {
     {
       quote: "<strong>Black Tie</strong>, from the creator of Font Awesome. On sale at the Kickstarter price for a limited time.",
       class: "black-tie",
-      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_2_kickstarter&utm_campaign=promo_4.4_update",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_2_kickstarter&utm_campaign=promo_4.5_update",
       btn_text: "Check it Out!"
     },
     {
       quote: "Want clean, minimalist icons? Check out <strong>Black Tie</strong>, the new multi-weight icon font from the maker of Font Awesome.",
       class: "black-tie",
-      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_5_clean_minimalist&utm_campaign=promo_4.4_update",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_5_clean_minimalist&utm_campaign=promo_4.5_update",
       btn_text: "Check it Out!"
     },
     {
       quote: "Want a different icon look? Check out <strong>Black Tie</strong>, our new multi-weight icon set.",
       class: "black-tie",
-      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_different_look&utm_campaign=promo_4.4_update",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_different_look&utm_campaign=promo_4.5_update",
       btn_text: "Check it Out!"
     },
     {
       quote: "Check out <strong>Black Tie</strong>, our new multi-weight icon set!",
       class: "black-tie",
-      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_7_our_new_multi_weight&utm_campaign=promo_4.4_update",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_7_our_new_multi_weight&utm_campaign=promo_4.5_update",
       btn_text: "Check it Out!"
     }
   ];

--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -3,26 +3,26 @@ $(function () {
 
   var ads = [
     {
-      quote: "Take your icon game to the next level. Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-      class: "fonticons",
+      quote: "Take your icon game to the next level. Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
+      class: "fort-awesome",
       url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_1_next_level&utm_campaign=promo_4.4_update",
       btn_text: "Gimme Some!"
     },
     {
-      quote: "Make your icons load 10x faster! Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-      class: "fonticons",
+      quote: "Make your icons load 10x faster! Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
+      class: "fort-awesome",
       url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_3_faster_loading&utm_campaign=promo_4.4_update",
       btn_text: "Gimme Some!"
     },
     {
-      quote: "Looking for other great icon sets? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-      class: "fonticons",
+      quote: "Looking for other great icon sets? Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
+      class: "fort-awesome",
       url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_4_more_icons&utm_campaign=promo_4.4_update",
       btn_text: "Gimme Some!"
     },
     {
-      quote: "Want to add your own icon? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-      class: "fonticons",
+      quote: "Want to add your own icon? Check out <strong>Fort Awesome</strong>, from the maker of Font Awesome.",
+      class: "fort-awesome",
       url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_your_own_icon&utm_campaign=promo_4.4_update",
       btn_text: "Gimme Some!"
     },
@@ -54,7 +54,7 @@ $(function () {
     }
   ];
 
-  selectFonticonsAd();
+  selectAd();
 
   // start the icon carousel
   $('#icon-carousel').carousel({
@@ -64,7 +64,7 @@ $(function () {
   $('[data-toggle="tooltip"]').tooltip();
   $('[data-toggle="popover"]').popover();
 
-  function selectFonticonsAd() {
+  function selectAd() {
     random_number = Math.floor(Math.random() * ads.length);
     random_ad = ads[random_number];
 

--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -2,61 +2,55 @@ $(function () {
   $("#newsletter").validate();
 
   var ads = [
-    // {
-    //   quote: "Take your icon game to the next level. Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-    //   class: "fonticons",
-    //   url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_1_next_level&utm_campaign=promo_4.4_update",
-    //   btn_text: "Gimme Some!"
-    // },
-    // {
-    //   quote: "Make your icons load 10x faster! Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-    //   class: "fonticons",
-    //   url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_3_faster_loading&utm_campaign=promo_4.4_update",
-    //   btn_text: "Gimme Some!"
-    // },
-    // {
-    //   quote: "Looking for other great icon sets? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-    //   class: "fonticons",
-    //   url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_4_more_icons&utm_campaign=promo_4.4_update",
-    //   btn_text: "Gimme Some!"
-    // },
-    // {
-    //   quote: "Want to add your own icon? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
-    //   class: "fonticons",
-    //   url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_your_own_icon&utm_campaign=promo_4.4_update",
-    //   btn_text: "Gimme Some!"
-    // },
-    //
-    //
-    // {
-    //   quote: "<strong>Black Tie</strong>, from the creator of Font Awesome. On sale at the Kickstarter price for a limited time.",
-    //   class: "black-tie",
-    //   url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_2_kickstarter&utm_campaign=promo_4.4_update",
-    //   btn_text: "Check it Out!"
-    // },
-    // {
-    //   quote: "Want clean, minimalist icons? Check out <strong>Black Tie</strong>, the new multi-weight icon font from the maker of Font Awesome.",
-    //   class: "black-tie",
-    //   url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_5_clean_minimalist&utm_campaign=promo_4.4_update",
-    //   btn_text: "Check it Out!"
-    // },
-    // {
-    //   quote: "Want a different icon look? Check out <strong>Black Tie</strong>, our new multi-weight icon set.",
-    //   class: "black-tie",
-    //   url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_different_look&utm_campaign=promo_4.4_update",
-    //   btn_text: "Check it Out!"
-    // },
-    // {
-    //   quote: "Check out <strong>Black Tie</strong>, our new multi-weight icon set!",
-    //   class: "black-tie",
-    //   url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_7_our_new_multi_weight&utm_campaign=promo_4.4_update",
-    //   btn_text: "Check it Out!"
-    // },
     {
-      quote: "<strong>Help make Font Awesome more awesome!</strong> Fill out a 6-minute survey and give us your feedback.",
-      class: "font-awesome-survey",
-      url: "http://fontawesome.io/survey/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_survey&utm_campaign=promo_4.5_update",
-      btn_text: "Take the survey!"
+      quote: "Take your icon game to the next level. Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
+      class: "fonticons",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_1_next_level&utm_campaign=promo_4.4_update",
+      btn_text: "Gimme Some!"
+    },
+    {
+      quote: "Make your icons load 10x faster! Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
+      class: "fonticons",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_3_faster_loading&utm_campaign=promo_4.4_update",
+      btn_text: "Gimme Some!"
+    },
+    {
+      quote: "Looking for other great icon sets? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
+      class: "fonticons",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_4_more_icons&utm_campaign=promo_4.4_update",
+      btn_text: "Gimme Some!"
+    },
+    {
+      quote: "Want to add your own icon? Check out <strong>Fonticons</strong>, from the maker of Font Awesome.",
+      class: "fonticons",
+      url: "https://fonticons.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_your_own_icon&utm_campaign=promo_4.4_update",
+      btn_text: "Gimme Some!"
+    },
+
+
+    {
+      quote: "<strong>Black Tie</strong>, from the creator of Font Awesome. On sale at the Kickstarter price for a limited time.",
+      class: "black-tie",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_2_kickstarter&utm_campaign=promo_4.4_update",
+      btn_text: "Check it Out!"
+    },
+    {
+      quote: "Want clean, minimalist icons? Check out <strong>Black Tie</strong>, the new multi-weight icon font from the maker of Font Awesome.",
+      class: "black-tie",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_5_clean_minimalist&utm_campaign=promo_4.4_update",
+      btn_text: "Check it Out!"
+    },
+    {
+      quote: "Want a different icon look? Check out <strong>Black Tie</strong>, our new multi-weight icon set.",
+      class: "black-tie",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_6_different_look&utm_campaign=promo_4.4_update",
+      btn_text: "Check it Out!"
+    },
+    {
+      quote: "Check out <strong>Black Tie</strong>, our new multi-weight icon set!",
+      class: "black-tie",
+      url: "http://blacktie.io/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=ad_7_our_new_multi_weight&utm_campaign=promo_4.4_update",
+      btn_text: "Check it Out!"
     }
   ];
 

--- a/src/assets/less/site/banner-ad.less
+++ b/src/assets/less/site/banner-ad.less
@@ -66,14 +66,14 @@
   }
 
   &.black-tie {
-    @black-tie-bg: #222222;
+    @black-tie-bg: #2E2E2E;
     background-color: @black-tie-bg;
     border-bottom: solid 1px mix(@black-tie-bg, #fff, 95%);
 
     .btn-primary {
-      @color: @black-tie-bg;
-      @background: mix(#fff,@black-tie-bg,90%);
-      @border: mix(#fff,@black-tie-bg,60%);
+      @color: mix(#fff, @black-tie-bg, 85%);
+      @background: darken(@black-tie-bg, 5%);
+      @border: darken(@black-tie-bg, 10%);
       font-weight: bold;
       color: @color;
       background-color: @background;
@@ -88,7 +88,7 @@
       &.active,
       .open > &.dropdown-toggle {
         color: #fff;
-        background-color: darken(@border, 3%);
+        background-color: darken(@background, 5%);
         border-color: darken(@border, 12%);
         border-bottom-color: darken(@border, 18%);
       }

--- a/src/assets/less/site/banner-ad.less
+++ b/src/assets/less/site/banner-ad.less
@@ -112,15 +112,16 @@
     }
   }
 
-  &.fonticons {
-    @fonticons-bg: #1c1e29;
-    @fonticons-orange: desaturate(#ff7f3f, 5%);
-    background-color: @fonticons-orange;
-    border-bottom: solid 1px mix(@fonticons-bg, @fonticons-orange, 15%);
+  &.fort-awesome {
+    @fort-awesome-color: #1C1E29;
+    @fort-awesome-color-accent: #525879;
+    @fort-awesome-bg: mix(@fort-awesome-color-accent, @fort-awesome-color, 15%);
+    background-color: @fort-awesome-bg;
+    border-bottom: solid 1px mix(@fort-awesome-bg, #000, 15%);
     .btn-primary {
       @color: #fff;
-      @background: mix(#fff,@fonticons-bg,10%);
-      @border: @fonticons-bg;
+      @background: mix(#fff,@fort-awesome-bg,15%);
+      @border: darken(@fort-awesome-bg, 5%);
       font-weight: bold;
       color: @color;
       background-color: @background;
@@ -135,7 +136,7 @@
       &.active,
       .open > &.dropdown-toggle {
         color: #fff;
-        background-color: darken(@border, 3%);
+        background-color: mix(@fort-awesome-color, @fort-awesome-color-accent, 30%);
         border-color: darken(@border, 12%);
         border-bottom-color: darken(@border, 18%);
       }


### PR DESCRIPTION
This work does the following:

* removes the banner add for typeform-based Font Awesome survey
* reinstates all other Fonticons/Black Tie banner ads
* changes references in code and content from "Fonticons" to "Fort Awesome"
* updates color combinations for Fort Awesome (using FA's off-black) and Black Tie banner ads

![screenshot 2016-03-10 11 36 10](https://cloud.githubusercontent.com/assets/163763/13676554/565923f0-e6b4-11e5-80d2-83231f31b978.png)

![screenshot 2016-03-10 11 36 15](https://cloud.githubusercontent.com/assets/163763/13676556/59e75938-e6b4-11e5-9c7b-81651d306ade.png)


**Note**: The survey page (http://fontawesome.io/survey) is still live to avoid any 404s from direct links or previous visits.

---

#### Reviewers

* [x] UI, FED, and content - @davegandy 
