### PR TITLE
Exclude icons.yml from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -32,7 +32,8 @@ stunnel.log
 .ruby-version
 
 # don't need these in the npm package.
-src/
+src/*
+!src/icons.yml
 _config.yml
 bower.json
 component.json


### PR DESCRIPTION
**Use case**
For a custom organisation library/framework that has its own documentation (style guide) and using the Sass build to customise the class prefix. It would be nice to generate an icon list (similar to the [official list](http://fontawesome.io/icons/)) that is specific to the custom build. 

I know it could be done just by saying _"Go to the official docs, replace the `fa-` prefix for [CUSTOM PREFIX] and ignore any icons before [PACKAGE VERSION]"_ 

... but I can't see any harm in including the yaml file :smiley_cat: ... plus I'm sure there are other use cases for having access to a full list of the icons. Like in [#4851](https://github.com/FortAwesome/Font-Awesome/issues/4851)

**Note: this will also include the `license.html` and `README.md-nobuild` because they match files that are never ignored**

> The following paths and files are never ignored, so adding them to .npmignore is pointless:
> - package.json
> - README (and its variants)
> - CHANGELOG (and its variants)
> - LICENSE / LICENCE

Taken from [NPM docs](https://docs.npmjs.com/misc/developers)
