### PR TITLE
FIX: Incorrect Info Icon Reference on Icon View

### DIFF
--- a/src/_layouts/icon.html
+++ b/src/_layouts/icon.html
@@ -52,7 +52,7 @@ relative_path: ../../
 <i class="fa fa-{{ page.icon.id }}"></i>
 {% endhighlight %}
         <br>
-        <div class="lead"><i class="fa fa-info-sign"></i> Looking for more? Check out the <a href="{{ page.relative_path }}examples/">examples</a>.</div>
+        <div class="lead"><i class="fa fa-info-circle"></i> Looking for more? Check out the <a href="{{ page.relative_path }}examples/">examples</a>.</div>
       </div>
       <div class="col-md-3 col-sm-3">
         <div class="vertical-ad">{% include ads/fusion.html %}</div>


### PR DESCRIPTION
This work makes a quick fix to an incorrect referenced info icon on doc icon view.