### PR TITLE
Fix: Remove a11y-friendly Text from Cheatsheet Glyphs

### DIFF
--- a/src/cheatsheet.html
+++ b/src/cheatsheet.html
@@ -25,7 +25,7 @@ relative_path: ../
     {% for icon in sorted_icons %}
     <div class="col-md-4 col-sm-6 col-lg-3">
       {% if icon.created >= site.fontawesome.major_version %}<small class="text-muted pull-right">{{ icon.created }}</small>{% endif %}
-      <i class="fa fa-fw" aria-hidden="true"><span class="sr-only">Copy to use {{ icon.class }}</span>&#x{{ icon.unicode }}</i>
+      <i class="fa fa-fw" aria-hidden="true" title="Copy to use {{ icon.class }}">&#x{{ icon.unicode }}</i>
       fa-{{ icon.class }}
       {% if icon.alias_of %} <span class="text-muted">(alias)</span>{% endif %}
       <span class="text-muted">[&amp;#x{{ icon.unicode }};]</span>


### PR DESCRIPTION
This work adjusts cheatsheet glyph content to not include a11y-friendly text, which was added as part of https://github.com/FortAwesome/Font-Awesome/pull/8879/commits/84ac1362f8b87582245f70c4982e7a6e980e7717. Instead it moves the assistive tech-minded text into the `title` attribute to still alert users of the action they can take.

- - -

FYI, @davegandy and @tagliala.