### PR TITLE
Adding 'wine' search filter to glass icon

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -9,6 +9,7 @@ icons:
       - bar
       - alcohol
       - liquor
+      - wine
     categories:
       - Web Application Icons
 


### PR DESCRIPTION
The alcoholics may disagree, but martini and wine glasses are visually similar enough that it may be good additional filter