### PR TITLE
Multiple changes in CDN links

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -59,10 +59,11 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/{{ site.jquery.version }}/jquery.min.js"></script>
   <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/{{ site.jquery_validate.version }}/jquery.validate.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/{{ site.bootstrap.version }}/js/bootstrap.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/algoliasearch.helper/2/algoliasearch.helper.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.2.2/backbone-min.js"></script>
+  <script src="https://cdn.jsdelivr.net/algoliasearch/3.13.1/algoliasearch.jquery.min.js" integrity="sha256-2MTQjOt4Q02v+W/QjgCO5yv+si9RAo/o/RGR5alVYzY=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/algoliasearch.helper/2.9.1/algoliasearch.helper.min.js" integrity="sha256-MhjLBzVVNkMEKnIE2ueYNb7QSj+oiSv4x89dlui09hg=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/underscorejs/1.8.3/underscore-min.js" integrity="sha256-obZACiHd7gkOk9iIL/pimWMTJ4W/pBsKu+oZnSeBIek=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/backbonejs/1.2.2/backbone-min.js" integrity="sha256-p6bkfFqmxtebrKOS+wyGi+Qf3d111eWUQP67keyXJ6Q=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/jsdelivr-rum/1.5/jsdelivr-rum.min.js" integrity="sha256-HlY2rbkgbiHhtilMXmQ86rjL/EIxGDtdg9GU9/T2ZxE=" crossorigin="anonymous"></script>
   <script src="{{ page.relative_path }}assets/js/site.js"></script>
   <script src="{{ page.relative_path }}assets/js/search.js"></script>
   </body>


### PR DESCRIPTION
- Moving the resources from CDNJs to JSDelivr. In HTTP/2 and SPDY it is recommended to host all dependencies in the same CDN or web server, so all resources are downloaded using the same HTTP connection. It's faster than establish a connection to two CDN providers. In the past using multiple CDN was the best option, but no longer. So we have to put them in just one CDN, I don't have any relation with JSDelivr but think is the best available option.
- Added SRI (integrity) to external scripts. This prevents an infection if the CDN is compromised.
- I removed version aliasing from Algolia (3) and put specific version (3.13.1). This way the cache TTL is longer and avoid breaking changes if the library is updated.
- I added the JSDelivr RUM script. This allow them to test the performance of downloading scripts and takes better load balancing decision for the CDN resources.