### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "extra": {
     "branch-alias": {
-      "dev-master": "4.0.x-dev"
+      "dev-master": "4.6.x-dev"
     }
   },
   "license": [


### PR DESCRIPTION
https://packagist.org/packages/fortawesome/font-awesome#dev-master is showing the "dev-master" branch as being in the "4.0.x-dev" branch when it is part of the "4.6.x-dev" branch.
