### PR TITLE
Syncing Up CDN-based Status Views with App

### DIFF
--- a/src/cdn/error.html
+++ b/src/cdn/error.html
@@ -5,20 +5,60 @@ relative_path: ../../
 ---
 
 <div class="container">
-  <div class="row">
-    <div class="col-md-6 col-md-offset-3 margin-top-lg">
-      <div class="well well-lg margin-top-xl margin-bottom-xl">
-        <h1 class="text-danger page-header"><i class="fa fa-exclamation-triangle"></i> Oh noes!</h1>
-        <p class="lead">
-          Something bad happened on our end when sending your embed code.
-          We've already been notified and are looking into it.
-        </p>
+  <div class="row margin-top-xl">
+
+    <div class="col-lg-7">
+      <div class="well well-lg margin-bottom-xl">
+        <h1 class="page-header text-danger">
+          <i class="fa fa-exclamation-triangle"></i>
+          Oh Noes!
+        </h1>
 
         <p class="lead">
-          Hang tight for just a bit and we should have things fixed up shortly.
+          <strong>Something bad happened on our end when sending your embed code.</strong>
+        </p>
+
+        <p>
+          We've already been notified and are looking into it. Hang tight for just a bit and we should have things fixed up shortly.
         </p>
       </div>
+    </div>
 
+    <div class="col-lg-4 col-lg-offset-1">
+
+      <ol class="list-unstyled gg gg-top">
+        <li class="gg-row">
+          <div class="gg-col">
+            <i class="fa fa-refresh fa-2x margin-right-lg text-muted"></i>
+          </div>
+          <div class="gg-col">
+            <h3 class="text-lg text-muted">If at first you don't succeed&hellip;</h3>
+
+            <p>
+              We'll be taking a look into things. But in the meantime, it may not hurt to <a href="{{ page.relative_path }}cdn/new/">try to request an embed code again</a>.
+            </p>
+
+            <hr class="hr-lg m-xs-y-lg">
+          </div>
+        </li>
+
+        <li class="gg-row">
+          <div class="gg-col">
+            <i class="fa fa-hourglass-end fa-2x margin-right-lg text-muted"></i>
+          </div>
+          <div class="gg-col">
+            <h3 class="text-lg text-muted">Been a while?</h3>
+
+            <p>
+              Still stuck and haven't heard from us? Let us know something is up.
+            </p>
+
+            <a href="mailto:cdn@fontawesome.com" class="btn btn-success btn-lg">
+              Contact us!
+            </a>
+          </div>
+        </li>
+      </ol>
     </div>
   </div>
 </div>

--- a/src/cdn/success.html
+++ b/src/cdn/success.html
@@ -5,20 +5,61 @@ relative_path: ../../
 ---
 
 <div class="container">
-  <div class="row">
-    <div class="col-md-6 col-md-offset-3 margin-top-lg">
-      <div class="well well-lg margin-top-xl margin-bottom-xl">
-        <h1 class="text-success page-header"><i class="fa fa-envelope"></i> On the way!</h1>
+  <div class="row margin-top-xl">
+    <div class="col-lg-7">
+      <div class="well well-lg margin-bottom-xl">
+        <h1 class="page-header text-success">
+          <i class="fa fa-check"></i>
+          Great Success!
+        </h1>
+
         <p class="lead">
-          We just sent you an email with your new Font Awesome CDN embed code and instructions
-          for what to do next!
+          <strong>Your embed code is on its way.</strong>
         </p>
 
-        <p class="lead text-muted">
-          If you don't see the email, maybe check your spam.
+        <p>
+          We just sent you an email with your new Font Awesome CDN embed code and instructions for what to do next!
+        </p>
+
+        <p>
+          If you don't see the email (sent by "Font Awesome") in your inbox, maybe check your spam folder first. Also, make sure you haven't previously unsubscribed. Still nothing? <a href="{{ page.relative_path }}cdn/new/">Try again</a> or <a href="https://cdn.fontawesome.com/help">get some help</a>.
         </p>
       </div>
+    </div>
 
+    <div class="col-lg-4 col-lg-offset-1">
+
+      <h2 class="sr-only">Next Steps</h2>
+
+      <ol class="list-unstyled gg gg-top">
+        <li class="gg-row">
+          <div class="gg-col p-xs-r-md">
+            <i class="fa fa-envelope fa-2x margin-right-lg text-muted"></i>
+          </div>
+          <div class="gg-col">
+            <h3 class="text-lg text-muted">Check your email</h3>
+
+            <p>
+              Your embed code should be waiting there for you. From there you can also register a Font Awesome CDN account to help you manage your icons even more easily.
+            </p>
+
+            <hr class="hr-lg m-xs-y-lg">
+          </div>
+        </li>
+
+        <li class="gg-row">
+          <div class="gg-col p-xs-r-md">
+            <i class="fa fa-flag-checkered fa-2x margin-right-lg text-muted"></i>
+          </div>
+          <div class="gg-col">
+            <h3 class="text-lg text-muted">Get ready to use Font Awesome</h3>
+
+            <p>
+              While you're waiting, dive into how to use Font Awesome. You'll want to add your embed code within the <code>&lt;head&gt;</code> of each template or page that you want to use Font Awesome on. Then, check out the <a href="{{ page.relative_path }}icons/">Font Awesome icons</a> and <a href="{{ page.relative_path }}examples/">examples</a> to learn how drop icons right into your UI.
+            </p>
+          </div>
+        </li>
+      </ol>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This work syncs up the UI of embed code request success and error views with the same views (https://cdn.fontawesome.com/register/error and https://cdn.fontawesome.com/register/success) at https://cdn.fontawesome.com.

---

#### Previews

![screenshot 2016-05-02 11 43 28](https://cloud.githubusercontent.com/assets/163763/14958953/296ec004-105b-11e6-98ba-132aac935137.png)

![screenshot 2016-05-02 11 43 34](https://cloud.githubusercontent.com/assets/163763/14958959/2bc687f6-105b-11e6-9ca6-48d78b713b4e.png)


---

#### Reviewers

* [x] UI and Copy - @davegandy 