### PR TITLE
avoid punctuation in some links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ created and maintained by [Dave Gandy](https://twitter.com/davegandy).
 Stay up to date with the latest release and announcements on Twitter:
 [@fontawesome](http://twitter.com/fontawesome).
 
-Get started at http://fontawesome.io!
+Get started at <http://fontawesome.io>!
 
 ## License
 - The Font Awesome font is licensed under the SIL OFL 1.1:
@@ -98,6 +98,6 @@ Build the project and documentation:
 
     $ bundle exec jekyll build
 
-Or serve it on a local server on http://localhost:7998/Font-Awesome/:
+Or serve it on a local server on >http://localhost:7998/Font-Awesome/>:
 
     $ bundle exec jekyll -w serve

--- a/README.md
+++ b/README.md
@@ -98,6 +98,6 @@ Build the project and documentation:
 
     $ bundle exec jekyll build
 
-Or serve it on a local server on >http://localhost:7998/Font-Awesome/>:
+Or serve it on a local server on `http://localhost:7998/Font-Awesome/`:
 
     $ bundle exec jekyll -w serve


### PR DESCRIPTION
For example on npm the link would be made with the colon in there.
