### PR TITLE
Update Getting Started Flow

### DIFF
--- a/src/_includes/jumbotron-carousel.html
+++ b/src/_includes/jumbotron-carousel.html
@@ -5,8 +5,7 @@
         <h1>Font Awesome</h1>
         <p>The iconic font and CSS toolkit</p>
         <div class="actions">
-          <a class="btn btn-default btn-lg" href="#modal-download" data-toggle="modal"
-             onClick="_gaq.push(['_trackEvent', 'Launch Modal', 'Launch Download Modal']);">
+          <a class="btn btn-default btn-lg" href="#modal-download" data-toggle="modal" onClick="_gaq.push(['_trackEvent', 'Launch Modal', 'Launch Download Modal']);">
             <i class="fa fa-download fa-lg" aria-hidden="true"></i>&nbsp;
             Download
           </a>

--- a/src/_includes/modals/download.html
+++ b/src/_includes/modals/download.html
@@ -10,48 +10,53 @@
         </h2>
       </div>
       <div class="modal-body">
-        <div class="text-lg margin-bottom-lg">
-          Before you download, check out our latest project: Fort Awesome&mdash;
+        <div class="well">
+          <h3 class="text-success margin-top-none margin-bottom-lg">Want the easiest way to use Font Awesome?</h3>
+          <p class="text-lg margin-bottom-lg"><strong>Font Awesome CDN</strong> gets you started in just 2 steps! And it comes with these free benefits&hellip;</p>
+
+          <div class="row">
+            <div class="col-md-6 col-sm-6 margin-bottom-lg">
+              <h5 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Icons on your site. Fast.</h5>
+              <p>Don't mess with files locally or in production. Get all {{ icons| size }} icons plus our CSS toolkit where you want.</p>
+            </div>
+            <div class="col-md-6 col-sm-6 margin-bottom-lg">
+              <h5 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Auto accessibility support</h5>
+              <p>We'll automate accessibility support so your site's icons work for the most people possible.</p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-6 col-sm-6 margin-bottom-lg">
+              <h5 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Super-simple upgrades</h5>
+              <p>Easily upgrade to the latest version of Font Awesome, all without pushing any code.</p>
+            </div>
+            <div class="col-md-6 col-sm-6 margin-bottom-lg">
+              <h5 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">A Faster Font Awesome</h5>
+              <p>Make you site load faster with our asynchronously loading icons and our already popular cached CDN.</p>
+            </div>
+          </div>
+
+          <form class="row" action="https://cdn.fontawesome.com/register" method="post">
+            <div class="col-sm-6 signup-input">
+              <label for="email" class="sr-only">Email address</label>
+              <input type="email" class="form-control input-lg margin-bottom" id="email" name="email" placeholder="Your email address">
+            </div>
+
+            <div class="col-sm-6 signup-button">
+              <button type="submit" class="btn btn-success btn-lg btn-block margin-bottom">Send a CDN embed code!</button>
+            </div>
+          </form>
         </div>
 
-        <div class="row">
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">More Sets</h4>
-            Font Awesome not the right look? We've got the perfect icon set for your website!
-          </div>
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Your Icons</h4>
-            Copy &amp; paste your own logo and icons directly into Fort Awesome. Easy peasy.
-          </div>
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Fonts Too!</h4>
-            Subset and serve your typefaces too! We've got some great ones to start with.
-          </div>
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Optimized</h4>
-            Subsetting your icons and typefaces often shrinks them by 95% or more!
-          </div>
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Hosted</h4>
-            No more messing with files! Update and deploy your icons to our CDN.
-          </div>
-          <div class="col-md-6 col-sm-6 margin-bottom-lg">
-            <h4 class="page-header margin-top-none padding-bottom-sm margin-bottom-sm">Faster</h4>
-            Optimized and hosted means your icons and typefaces load much faster.
-          </div>
-        </div>
+        <hr>
 
-        <a href="https://fortawesome.com/?utm_source=font_awesome_homepage&utm_medium=display&utm_content=download_modal&utm_campaign=promo_5.0_update" class="btn btn-success btn-lg btn-block">
-          Take your icon game <br class="visible-xs" />to the next level with
-          <h2 class="margin-top-sm margin-bottom-sm hidden-xs"><i class="fas fas-fort-logo fas-lg valign-baseline"></i>&nbsp; Fort Awesome</h2>
-          <h3 class="margin-top-sm margin-bottom-sm visible-xs"><i class="fas fas-fort-logo fas-lg valign-baseline"></i>&nbsp; Fort Awesome</h3>
-        </a>
-        <div class="text-center margin-top-sm margin-bottom-sm">or</div>
         <a class="btn btn-default btn-lg btn-block" href="{{ page.relative_path }}assets/font-awesome-{{ site.fontawesome.version }}.zip"
            onClick="_gaq.push(['_trackEvent', 'Outbound Modal Link', 'Download on GitHub']);">
           No thanks, just download <br class="visible-xs" />Font Awesome
         </a>
 
+        <div class="text-muted text-center margin-top">
+          <small>We get it - downloading is great for being particular about your Front End assets (and for use in Design tools).</small>
+        </div>
       </div>
     </div>
   </div>

--- a/src/_includes/modals/download.html
+++ b/src/_includes/modals/download.html
@@ -12,7 +12,7 @@
       <div class="modal-body">
         <div class="well">
           <h3 class="text-success margin-top-none margin-bottom-lg">Want the easiest way to use Font Awesome?</h3>
-          <p class="text-lg margin-bottom-lg"><strong>Font Awesome CDN</strong> gets you started in just 2 steps! And it comes with these free benefits&hellip;</p>
+          <p class="text-lg margin-bottom-lg"><strong>Font Awesome CDN</strong> gets you started in just 2 steps! Plus, you get all this free stuff&hellip;</p>
 
           <div class="row">
             <div class="col-md-6 col-sm-6 margin-bottom-lg">
@@ -51,6 +51,7 @@
 
         <a class="btn btn-default btn-lg btn-block" href="{{ page.relative_path }}assets/font-awesome-{{ site.fontawesome.version }}.zip"
            onClick="_gaq.push(['_trackEvent', 'Outbound Modal Link', 'Download on GitHub']);">
+         <i class="fa fa-download fa-lg" aria-hidden="true"></i>&nbsp;
           No thanks, just download <br class="visible-xs" />Font Awesome
         </a>
 

--- a/src/assets/less/site/bootstrap/variables.less
+++ b/src/assets/less/site/bootstrap/variables.less
@@ -73,6 +73,8 @@
 // Components
 @component-active-bg:            @fa-green;
 
+// Forms
+@input-border-focus:             lighten(@fa-green, 5%);
 
 // Labels
 @label-brand-bg:                    @fa-green;

--- a/src/get-started.html
+++ b/src/get-started.html
@@ -96,8 +96,8 @@ relative_path: ../
       </div>
 
       <div class="col-md-3">
-        <a class="btn btn-default btn-lg btn-block" href="#modal-download" data-toggle="modal"
-           onClick="_gaq.push(['_trackEvent', 'Launch Modal', 'Launch Download Modal']);">
+        <a class="btn btn-default btn-lg btn-block" href="{{ page.relative_path }}assets/font-awesome-{{ site.fontawesome.version }}.zip"
+           onClick="_gaq.push(['_trackEvent', 'Outbound Modal Link', 'Download on GitHub']);">
           <i class="fa fa-download fa-lg margin-right-sm"></i>
           Download
         </a>

--- a/src/get-started.html
+++ b/src/get-started.html
@@ -32,19 +32,6 @@ relative_path: ../
       </div>
     </form>
 
-    <!-- CASE: error -->
-    <!-- <form class="row" action="http://fontawesome-cdn.dev:4000/register" method="post">
-      <div class="col-sm-6 signup-input has-error">
-        <label for="cdn-email" class="sr-only">Email address</label>
-        <input type="email" class="form-control input-lg margin-bottom" id="email" name="email" placeholder="Your email address">
-        <p id="cdn-email-error" class="help-block">Email address must be valid.</p>
-      </div>
-
-      <div class="col-sm-6 signup-button">
-        <button type="submit" class="btn btn-success btn-lg btn-block margin-bottom">Send my Font Awesome embed code!</button>
-      </div>
-    </form> -->
-
     <p class="help-block margin-top-none margin-bottom-sm"><a role="button" data-toggle="collapse" href="#cdn-why-email" aria-expanded="false" aria-controls="collapseExample">Why do we need your email address?</a></p>
 
     <div class="collapse" id="cdn-why-email">


### PR DESCRIPTION
This work preemptively adjusts the following:
- changes the Download Modal UI to feature the FA CDN rather than Fort Awesome
- removes the download modal from firing when choosing to download from the Get Started page
-  #quick clean up - removes unused CDN error state code + styling for focused text inputs

![screenshot 2016-05-12 17 16 29](https://cloud.githubusercontent.com/assets/163763/15230749/4f1efe7e-1865-11e6-9de2-a0f2ea11e2ed.png)

---
##### Reviewers
- [x] @davegandy - UI and FED

---

FYI, @tagliala.
