### PR TITLE
Adding 'font-awesome.css' to 'main' node for yeoman angular projects

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
   "license": ["OFL-1.1", "MIT", "CC-BY-3.0"],
   "main": [
     "less/font-awesome.less",
-    "scss/font-awesome.scss"
+    "scss/font-awesome.scss",
+    "css/font-awesome.css"
   ],
   "ignore": [
     "*/.*",


### PR DESCRIPTION
Adding the reference to 'css/font-awesome.css' will allow yeoman angular projects to use font-awesome from the bower install method.