### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "The iconic font and CSS framework",
   "version": "4.6.3",
   "style": "css/font-awesome.css",
+  "main": "scss/font-awesome.scss",
   "keywords": ["font", "awesome", "fontawesome", "icon", "font", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
This allows support for `npm install font-awesome` and `@import "font-awesome"` to just work
when using a custom sass importer like [node-sass-import](https://www.npmjs.com/package/node-sass-import).
