### PR TITLE
production file for browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "less/font-awesome.less",
     "scss/font-awesome.scss"
   ],
+  "browser": [ "css/font-awesome.min.css"],
   "ignore": [
     "*/.*",
     "*.json",


### PR DESCRIPTION
> because development files (ex: `.scss`, `.coffee`, ...)  isn't actually good for browsers to digest.

useful for project which behavior [like this one](http://codepen.io/tnga/pen/OXwjao); considering this conversation bower/bower#2312