### PR TITLE
In class "fa" do not inherit text-indent

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -16,6 +16,7 @@
   font: normal normal normal 14px/1 FontAwesome;
   font-size: inherit;
   text-rendering: auto;
+  text-indent: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
Set text-indent explicitly to 0 in case icon is within a region of indented text.

See [Issue 8945](https://github.com/FortAwesome/Font-Awesome/issues/8945).