### PR TITLE
Changed links in examples page to be fragment links.

### DIFF
--- a/src/_includes/examples/accessible.html
+++ b/src/_includes/examples/accessible.html
@@ -5,11 +5,11 @@
   <div class="row">
     <div class="col-md-3 col-sm-4">
       <p>
-        <a class="btn btn-default" href="path/to/settings" aria-label="Settings">
+        <a class="btn btn-default" href="#path/to/settings" aria-label="Settings">
           <i class="fa fa-cog" aria-hidden="true"></i>
         </a>
 
-        <a class="btn btn-danger" href="path/to/settings" aria-label="Delete">
+        <a class="btn btn-danger" href="#path/to/delete" aria-label="Delete">
           <i class="fa fa-trash-o" aria-hidden="true"></i>
         </a>
 
@@ -26,19 +26,17 @@
         <span class="sr-only">Saving. Hang tight!</span>
       </p>
 
-      <p>
-        <div class="input-group margin-bottom-sm">
-          <span class="input-group-addon"><i class="fa fa-envelope-o fa-fw" aria-hidden="true"></i></span>
-          <input class="form-control" type="text" placeholder="Email address">
-        </div>
-        <div class="input-group">
-          <span class="input-group-addon"><i class="fa fa-key fa-fw" aria-hidden="true"></i></span>
-          <input class="form-control" type="password" placeholder="Password">
-        </div>
-      </p>
+      <div class="input-group margin-bottom-sm">
+        <span class="input-group-addon"><i class="fa fa-envelope-o fa-fw" aria-hidden="true"></i></span>
+        <input class="form-control" type="text" placeholder="Email address">
+      </div>
+      <div class="input-group margin-bottom">
+        <span class="input-group-addon"><i class="fa fa-key fa-fw" aria-hidden="true"></i></span>
+        <input class="form-control" type="password" placeholder="Password">
+      </div>
 
       <p>
-        <a href="path/to/shopping/cart" class="btn btn-primary" aria-label="View 3 items in your shopping cart">
+        <a href="#path/to/shopping/cart" class="btn btn-primary" aria-label="View 3 items in your shopping cart">
           <i class="fa fa-shopping-cart" aria-hidden="true"></i>
         </a>
       </p>
@@ -54,11 +52,11 @@
       </p>
 
 {% highlight html %}
-<a class="btn btn-default" href="path/to/settings" aria-label="Settings">
+<a class="btn btn-default" href="#path/to/settings" aria-label="Settings">
   <i class="fa fa-cog" aria-hidden="true"></i>
 </a>
 
-<a class="btn btn-danger" href="path/to/settings" aria-label="Delete">
+<a class="btn btn-danger" href="#path/to/delete" aria-label="Delete">
   <i class="fa fa-trash-o" aria-hidden="true"></i>
 </a>
 
@@ -87,7 +85,7 @@
 {% endhighlight %}
 
 {% highlight html %}
-<a href="path/to/shopping/cart" class="btn btn-primary" aria-label="View 3 items in your shopping cart">
+<a href="#path/to/shopping/cart" class="btn btn-primary" aria-label="View 3 items in your shopping cart">
   <i class="fa fa-shopping-cart" aria-hidden="true"></i>
 </a>
 {% endhighlight %}

--- a/src/_includes/examples/bootstrap.html
+++ b/src/_includes/examples/bootstrap.html
@@ -3,27 +3,27 @@
   <div class="row">
     <div class="col-md-3 col-sm-4">
       <p>
-        <a class="btn btn-danger" href="#">
+        <a class="btn btn-danger" href="#path/to/delete">
           <i class="fa fa-trash-o fa-lg"></i> Delete</a>
-        <a class="btn btn-default btn-sm" href="#">
+        <a class="btn btn-default btn-sm" href="#path/to/settings">
           <i class="fa fa-cog"></i> Settings</a>
       </p>
       <p>
-        <a class="btn btn-lg btn-success" href="#">
+        <a class="btn btn-lg btn-success" href="#path/to/awesome">
           <i class="fa fa-flag fa-2x pull-left"></i> Font Awesome<br>Version {{ site.fontawesome.version }}</a>
       </p>
       <div class="margin-bottom">
         <div class="btn-group">
-          <a class="btn btn-default" href="#">
+          <a class="btn btn-default" href="#align-left">
             <i class="fa fa-align-left" title="Align Left"></i>
           </a>
-          <a class="btn btn-default" href="#">
+          <a class="btn btn-default" href="#align-center">
             <i class="fa fa-align-center" title="Align Center"></i>
           </a>
-          <a class="btn btn-default" href="#">
+          <a class="btn btn-default" href="#align-right">
             <i class="fa fa-align-right" title="Align Right"></i>
           </a>
-          <a class="btn btn-default" href="#">
+          <a class="btn btn-default" href="#align-justify">
             <i class="fa fa-align-justify" title="Align Justify"></i>
           </a>
         </div>
@@ -40,16 +40,16 @@
       </div>
       <div class="margin-bottom">
         <div class="btn-group open">
-          <a class="btn btn-primary" href="#"><i class="fa fa-user fa-fw"></i> User</a>
+          <a class="btn btn-primary" href="#user"><i class="fa fa-user fa-fw"></i> User</a>
           <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
             <span class="fa fa-caret-down" title="Toggle dropdown menu"></span>
           </a>
           <ul class="dropdown-menu">
-            <li><a href="#"><i class="fa fa-pencil fa-fw"></i> Edit</a></li>
-            <li><a href="#"><i class="fa fa-trash-o fa-fw"></i> Delete</a></li>
-            <li><a href="#"><i class="fa fa-ban fa-fw"></i> Ban</a></li>
+            <li><a href="#edit"><i class="fa fa-pencil fa-fw"></i> Edit</a></li>
+            <li><a href="#delete"><i class="fa fa-trash-o fa-fw"></i> Delete</a></li>
+            <li><a href="#ban"><i class="fa fa-ban fa-fw"></i> Ban</a></li>
             <li class="divider"></li>
-            <li><a href="#"><i class="fa fa-unlock"></i> Make admin</a></li>
+            <li><a href="#make-admin"><i class="fa fa-unlock"></i> Make admin</a></li>
           </ul>
         </div>
       </div>
@@ -60,25 +60,25 @@
         Font Awesome works great with the full range of Bootstrap components.
       </p>
 {% highlight html %}
-<a class="btn btn-danger" href="#">
+<a class="btn btn-danger" href="#path/to/delete">
   <i class="fa fa-trash-o fa-lg"></i> Delete</a>
-<a class="btn btn-default btn-sm" href="#">
+<a class="btn btn-default btn-sm" href="#path/to/settings">
   <i class="fa fa-cog"></i> Settings</a>
 
-<a class="btn btn-lg btn-success" href="#">
+<a class="btn btn-lg btn-success" href="#path/to/awesome">
   <i class="fa fa-flag fa-2x pull-left"></i> Font Awesome<br>Version {{ site.fontawesome.version }}</a>
 
 <div class="btn-group">
-  <a class="btn btn-default" href="#">
+  <a class="btn btn-default" href="#align-left">
     <i class="fa fa-align-left" title="Align Left"></i>
   </a>
-  <a class="btn btn-default" href="#">
+  <a class="btn btn-default" href="#align-center">
     <i class="fa fa-align-center" title="Align Center"></i>
   </a>
-  <a class="btn btn-default" href="#">
+  <a class="btn btn-default" href="#align-right">
     <i class="fa fa-align-right" title="Align Right"></i>
   </a>
-  <a class="btn btn-default" href="#">
+  <a class="btn btn-default" href="#align-justify">
     <i class="fa fa-align-justify" title="Align Justify"></i>
   </a>
 </div>
@@ -93,16 +93,16 @@
 </div>
 
 <div class="btn-group open">
-  <a class="btn btn-primary" href="#"><i class="fa fa-user fa-fw"></i> User</a>
+  <a class="btn btn-primary" href="#user"><i class="fa fa-user fa-fw"></i> User</a>
   <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
     <span class="fa fa-caret-down" title="Toggle dropdown menu"></span>
   </a>
   <ul class="dropdown-menu">
-    <li><a href="#"><i class="fa fa-pencil fa-fw"></i> Edit</a></li>
-    <li><a href="#"><i class="fa fa-trash-o fa-fw"></i> Delete</a></li>
-    <li><a href="#"><i class="fa fa-ban fa-fw"></i> Ban</a></li>
+    <li><a href="#edit"><i class="fa fa-pencil fa-fw"></i> Edit</a></li>
+    <li><a href="#delete"><i class="fa fa-trash-o fa-fw"></i> Delete</a></li>
+    <li><a href="#ban"><i class="fa fa-ban fa-fw"></i> Ban</a></li>
     <li class="divider"></li>
-    <li><a href="#"><i class="fa fa-unlock"></i> Make admin</a></li>
+    <li><a href="#make-admin"><i class="fa fa-unlock"></i> Make admin</a></li>
   </ul>
 </div>
 {% endhighlight %}


### PR DESCRIPTION
Rebase of #10061

Some buttons in the examples page linked to non-existent pages. Changed to those to fragment links so that users won't be linked elsewhere.
