### PR TITLE
Adding Fonts and CSS to be tracked by Main Bower Files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,15 @@
   "devDependencies": {},
   "license": ["OFL-1.1", "MIT", "CC-BY-3.0"],
   "main": [
+    "css/font-awasome.css",
     "less/font-awesome.less",
-    "scss/font-awesome.scss"
+    "scss/font-awesome.scss",
+    "fonts/fontawesome-webfont.eot",
+    "fonts/fontawesome-webfont.svg",
+    "fonts/fontawesome-webfont.ttf",
+    "fonts/fontawesome-webfont.woff",
+    "fonts/fontawesome-webfont.woff2",
+    "fonts/FontAwesome.otf"
   ],
   "ignore": [
     "*/.*",


### PR DESCRIPTION
So, as the title suggests, I added the font files and the css file to the main property in the bower.json file.

I did it because I was struggling to perform a simple task of working the font files and copying it to my dist folder using a plugin called [main-bower-files](https://www.npmjs.com/package/main-bower-files).

When searching about this problem, I found an explanation on how the plugin works and how it maps the dependencies:

![image](https://cloud.githubusercontent.com/assets/2649772/20242732/8c884bca-a920-11e6-992e-b53f1b92d5be.png)

So, in order to make it less painful and more automatic the process of mapping dependencies, I suggest adding these changes to main property, so the plugin will be able to map such files as well as .scss and .less files that are already been mapped.

Thanks 😄 