### PR TITLE
Fix cheatsheet print layout

### DIFF
--- a/src/assets/less/site.less
+++ b/src/assets/less/site.less
@@ -18,6 +18,7 @@
 @import "site/bootstrap/modals";
 
 @import "site/layout";
+@import "site/print";
 @import "site/social-buttons";
 @import "site/jumbotron-carousel";
 @import "site/stripe-ad";

--- a/src/assets/less/site/print.less
+++ b/src/assets/less/site/print.less
@@ -1,0 +1,5 @@
+@media print {
+  .col-print-4 {
+    .make-xs-column(4);
+  }
+}

--- a/src/cheatsheet.html
+++ b/src/cheatsheet.html
@@ -23,7 +23,7 @@ relative_path: ../
     {% assign sorted_icons = icons | expand_aliases | sort_by:'class' %}
 
     {% for icon in sorted_icons %}
-    <div class="col-md-4 col-sm-6 col-lg-3">
+    <div class="col-md-4 col-sm-6 col-lg-3 col-print-4">
       {% if icon.created >= site.fontawesome.major_version %}<small class="text-muted pull-right">{{ icon.created }}</small>{% endif %}
       <i class="fa fa-fw" aria-hidden="true" title="Copy to use {{ icon.class }}">&#x{{ icon.unicode }}</i>
       fa-{{ icon.class }}

--- a/src/cheatsheet.html
+++ b/src/cheatsheet.html
@@ -25,7 +25,7 @@ relative_path: ../
     {% for icon in sorted_icons %}
     <div class="col-md-4 col-sm-6 col-lg-3 col-print-4">
       {% if icon.created >= site.fontawesome.major_version %}<small class="text-muted pull-right">{{ icon.created }}</small>{% endif %}
-      <i class="fa fa-fw" aria-hidden="true" title="Copy to use {{ icon.class }}">&#x{{ icon.unicode }}</i>
+      <i class="fa fa-fw" aria-hidden="true" title="Copy to use {{ icon.class }}">&#x{{ icon.unicode }};</i>
       fa-{{ icon.class }}
       {% if icon.alias_of %} <span class="text-muted">(alias)</span>{% endif %}
       <span class="text-muted">[&amp;#x{{ icon.unicode }};]</span>


### PR DESCRIPTION
This PR changes the print layout, showing three icons per row instead of
one. In this way we can solve an issue with the Bootstrap grid, which
for some reason limits the output to three pages when printing the
cheatsheet.

Fix: #10395

Before: [Font Awesome Cheatsheet.pdf](https://github.com/FortAwesome/Font-Awesome/files/659571/Font.Awesome.Cheatsheet.pdf)

After: [Font Awesome Cheatsheet (2).pdf](https://github.com/FortAwesome/Font-Awesome/files/659572/Font.Awesome.Cheatsheet.2.pdf)
