### PR TITLE
Set default file on jsDelivr

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "The iconic font and CSS framework",
   "version": "4.7.0",
   "style": "css/font-awesome.css",
+  "jsdelivr": "css/font-awesome.min.css",
   "keywords": ["font", "awesome", "fontawesome", "icon", "bootstrap"],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
I'm adding the default file to jsDelivr, so people [can easily find it](https://www.jsdelivr.com/package/npm/font-awesome). Closes #11531
