### PR TITLE
Added "main" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "font-awesome",
   "description": "The iconic font and CSS framework",
   "version": "4.7.0",
+  "main": "css/font-awesome.min.css",
   "style": "css/font-awesome.css",
   "keywords": ["font", "awesome", "fontawesome", "icon", "bootstrap"],
   "homepage": "http://fontawesome.io/",


### PR DESCRIPTION
Right now to import Font-Awesome into a React project it has to be done like this (after `npm install font-awesome`):

```js
import React from 'react';
import ReactDOM from 'react-dom';
import 'picnic';
import 'font-awesome/css/font-awesome.min.css';

// ...
```

However, as you can see from the line before, I can import my own library Picnic CSS with just `import 'picnic'`. This is because [inside Picnic CSS' package.json](https://github.com/franciscop/picnic/blob/master/package.json#L11) I have set this property:

```js
 "main": "picnic.min.css",
```

So I am proposing to add the same property for Font-Awesome to be able to import Font-Awesome with just this code:

```js
import React from 'react';
import ReactDOM from 'react-dom';
import 'picnic';
import 'font-awesome';

// ...
```

This will make it really intuitive for React devs to install and use Font-Awesome without having to dig into the code/repository to find out where the actual package is located.