### PR TITLE
In IE11 double focus bug (accessibility related)

### DIFF
--- a/advanced-options/use-with-node-js/fontawesome/index.es.js
+++ b/advanced-options/use-with-node-js/fontawesome/index.es.js
@@ -1081,6 +1081,7 @@ var attributesParser = function (node) {
       extraAttributes['aria-labelledby'] = config$1.replacementClass + '-title-' + nextUniqueId();
     } else {
       extraAttributes['aria-hidden'] = 'true';
+      extraAttributes['focusable'] = 'false';
     }
   }
 
@@ -1260,6 +1261,7 @@ function generateLayersText(node, nodeMeta) {
 
   if (config$1.autoA11y && !title) {
     extra.attributes['aria-hidden'] = 'true';
+    extra.attributes['focusable'] = 'false';
   }
 
   return [node, makeLayersTextAbstract({
@@ -1659,6 +1661,7 @@ var icon = resolveIcons(function (iconDefinition) {
         attributes['aria-labelledby'] = config$1.replacementClass + '-title-' + nextUniqueId();
       } else {
         attributes['aria-hidden'] = 'true';
+        attributes['focusable'] = 'false';
       }
     }
 

--- a/advanced-options/use-with-node-js/fontawesome/index.js
+++ b/advanced-options/use-with-node-js/fontawesome/index.js
@@ -1087,6 +1087,7 @@ var attributesParser = function (node) {
       extraAttributes['aria-labelledby'] = config$1.replacementClass + '-title-' + nextUniqueId();
     } else {
       extraAttributes['aria-hidden'] = 'true';
+      extraAttributes['focusable'] = 'false';
     }
   }
 
@@ -1266,6 +1267,7 @@ function generateLayersText(node, nodeMeta) {
 
   if (config$1.autoA11y && !title) {
     extra.attributes['aria-hidden'] = 'true';
+	extra.attributes['focusable'] = 'false';
   }
 
   return [node, makeLayersTextAbstract({
@@ -1665,6 +1667,7 @@ var icon = resolveIcons(function (iconDefinition) {
         attributes['aria-labelledby'] = config$1.replacementClass + '-title-' + nextUniqueId();
       } else {
         attributes['aria-hidden'] = 'true';
+        attributes['focusable'] = 'false';
       }
     }
 

--- a/svg-with-js/js/fontawesome-all.js
+++ b/svg-with-js/js/fontawesome-all.js
@@ -2550,6 +2550,7 @@ var attributesParser = function (node) {
       extraAttributes['aria-labelledby'] = config.replacementClass + '-title-' + nextUniqueId();
     } else {
       extraAttributes['aria-hidden'] = 'true';
+      extraAttributes['focusable'] = 'false';
     }
   }
 
@@ -2729,6 +2730,7 @@ function generateLayersText(node, nodeMeta) {
 
   if (config.autoA11y && !title) {
     extra.attributes['aria-hidden'] = 'true';
+    extra.attributes['focusable'] = 'false';
   }
 
   return [node, makeLayersTextAbstract({
@@ -3128,6 +3130,7 @@ var icon = resolveIcons(function (iconDefinition) {
         attributes['aria-labelledby'] = config.replacementClass + '-title-' + nextUniqueId();
       } else {
         attributes['aria-hidden'] = 'true';
+        attributes['focusable'] = 'false';
       }
     }
 

--- a/svg-with-js/js/fontawesome.js
+++ b/svg-with-js/js/fontawesome.js
@@ -1084,6 +1084,7 @@ var attributesParser = function (node) {
       extraAttributes['aria-labelledby'] = config.replacementClass + '-title-' + nextUniqueId();
     } else {
       extraAttributes['aria-hidden'] = 'true';
+      extraAttributes['focusable'] = 'false';
     }
   }
 
@@ -1263,6 +1264,7 @@ function generateLayersText(node, nodeMeta) {
 
   if (config.autoA11y && !title) {
     extra.attributes['aria-hidden'] = 'true';
+    extra.attributes['focusable'] = 'false';
   }
 
   return [node, makeLayersTextAbstract({
@@ -1662,6 +1664,7 @@ var icon = resolveIcons(function (iconDefinition) {
         attributes['aria-labelledby'] = config.replacementClass + '-title-' + nextUniqueId();
       } else {
         attributes['aria-hidden'] = 'true';
+	    attributes['focusable'] = 'false';
       }
     }
 


### PR DESCRIPTION
In IE11 if you tab through links (or any focusable element) containing SVG elements it will have two tab stops.

Fix is to add focusable="false" to the SVG element.
This works around an IE11 bug that defaults SVG elements to focusable="true".
The double focus can also cause some screen readers to double-read.

Example Page: https://labs.levelaccess.com/index.php/Remove_SVG_from_Tab_Order
Also See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [ ] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
