### PR TITLE
replaced null by empty array

### DIFF
--- a/advanced-options/metadata/icons.json
+++ b/advanced-options/metadata/icons.json
@@ -14325,7 +14325,7 @@
     ],
     "ligatures": [],
     "search": {
-      "terms": null
+      "terms": []
     },
     "styles": [
       "solid",


### PR DESCRIPTION
replaced null by empty array in Folder search terms, to prevent isArray check when iterating icons

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x ] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
