### PR TITLE
Remove vertical-align on fa-icon mixin to fix alignment

### DIFF
--- a/less/_mixins.less
+++ b/less/_mixins.less
@@ -9,7 +9,6 @@
   font-variant: normal;
   font-weight: normal;
   line-height: 1;
-  vertical-align: -.125em;
 }
 
 .fa-icon-rotate(@degrees, @rotation) {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -2,14 +2,13 @@
 // --------------------------
 
 @mixin fa-icon {
-  -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   font-style: normal;
   font-variant: normal;
   font-weight: normal;
   line-height: 1;
-  vertical-align: -.125em;
 }
 
 @mixin fa-icon-rotate($degrees, $rotation) {


### PR DESCRIPTION
When using `fa-icon` mixin, the displayed icon seems to not be aligned as expected because of custom `vertical-align`.

See this reduced test case: https://codepen.io/anon/pen/ErZXgv

Unless `vertical-align` is still here for a purpose (I didn't find a reason), I suggest to remove it to fix this alignment issue.
