### PR TITLE
Fix definitions for DOM interface

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
@@ -100,11 +100,15 @@ export interface IconParams extends Params {
   symbol?: FaSymbol;
   mask?: IconLookup;
 }
+export interface WatchOptions {
+	autoReplaceSvgRoot: HTMLElement;
+	observeMutationsRoot: HTMLElement;
+}
 export interface DOM {
   i2svg(params?: { node: Node; callback: () => void }): Promise<void>;
   css(): string;
-  insertCss(): string;
-  watch(): void;
+  insertCss(css: string): void;
+  watch(params?: WatchOptions): void;
 }
 type IconDefinitionOrPack = IconDefinition | IconPack;
 export interface Library {


### PR DESCRIPTION
DOM interfaces were off slightly from published API.  Adjusted them so TS users can use accurately

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
