### PR TITLE
added !default flag to font-display variable

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -3,7 +3,7 @@
 
 $fa-font-path:                "../webfonts" !default;
 $fa-font-size-base:           16px !default;
-$fa-font-display:             auto;
+$fa-font-display:             auto !default;
 $fa-css-prefix:               fa !default;
 $fa-version:                  "5.7.2" !default;
 $fa-border-color:             #eee !default;


### PR DESCRIPTION
I was looking at some of the Lighthouse performance suggestions for our application, one of which was to leverage the font-display feature, but I noticed that the font-display property for font-awesome did not have a Sass !default flag so could not be assigned.

As a side note, is the font-display feature likely to be added to FA4?