### PR TITLE
Resolve typings for unit testing

### DIFF
--- a/js-packages/@fortawesome/fontawesome-common-types/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-common-types/index.d.ts
@@ -14,6 +14,14 @@ export interface IconDefinition extends IconLookup {
     string, // unicode
     string // svgPathData
   ];
+
+  [index: string]: [
+    number, // width
+    number, // height
+    string[], // ligatures
+    string, // unicode
+    string // svgPathData
+  ] | IconName | IconPrefix;
 }
 
 export interface IconPack {

--- a/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
@@ -110,4 +110,5 @@ type IconDefinitionOrPack = IconDefinition | IconPack;
 export interface Library {
   add(...definitions: IconDefinitionOrPack[]): void;
   reset(): void;
+  readonly definitions: {fas: IconDefinition, fab: IconDefinition, far: IconDefinition, fal: IconDefinition};
 }


### PR DESCRIPTION
This allows unit tests to be written on the library. Previously a "ts-ignore" statement would be required for this as the TypeScript Compiler would claim that "definitions" did not exist on "Library", despite the fact that when logging the full "Library" it most certianly did. I've made the property readonly since it should be immutable (as the "add" method should be used to add new definitions) and the index signature added to IconDefinitions is to satisfy the TypeScript compiler when the compiler option of "strict" (or "NoImplicitAny") is enabled.

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
