### PR TITLE
Allow pause in MUTATION_OBSERVER with config.observeMutations

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/index.es.js
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.es.js
@@ -1417,6 +1417,9 @@ function observe(options) {
       observeMutationsRoot = _options$observeMutat === void 0 ? DOCUMENT : _options$observeMutat;
   mo = new MUTATION_OBSERVER(function (objects) {
     if (disabled) return;
+    if (!config.observeMutations) {
+      return;
+    }
     toArray(objects).forEach(function (mutationRecord) {
       if (mutationRecord.type === 'childList' && mutationRecord.addedNodes.length > 0 && !isWatched(mutationRecord.addedNodes[0])) {
         if (config.searchPseudoElements) {


### PR DESCRIPTION
`config.observeMutations` is only checked before the MUTATION_OBSERVER is created, but I need this check at runtime when the DOM is too busy. The disable function isn't exposed to an interface. unwatch() is also not available. This was the simplest change.

This change allows the DOM.watch() to be paused in cases that could cause an out of memory error.
Issue link:
[https://github.com/FortAwesome/Font-Awesome/issues/15858](https://github.com/FortAwesome/Font-Awesome/issues/15858)

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [X] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
