### PR TITLE
Update TS definition to include IconDefinition as an option to IconProp

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
@@ -17,7 +17,7 @@ export function layer(
   params?: LayerParams
 ): Layer;
 export function icon(icon: IconName | IconLookup, params?: IconParams): Icon;
-export type IconProp = IconName | [IconPrefix, IconName] | IconLookup;
+export type IconProp = IconName | [IconPrefix, IconName] | IconLookup | IconDefinition;
 export type FlipProp = "horizontal" | "vertical" | "both";
 export type SizeProp =
   | "xs"


### PR DESCRIPTION
At least in `@fortawesome/react-fontawesome`, the `icon` prop can take an imported icon definition.  But this is currently showing as an error in my TypeScript project because the the types don't include that.

This doesn't quite solve it, because the inferred type from the icon import doesn't seem to exactly match, but this can be taken care of with `as IconDefinition`:

```jsx
<FontAwesomeIcon icon={faExclamationCircle as IconDefinition} />
```

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
