### PR TITLE
Fix sass division deprecation

### DIFF
--- a/scss/_larger.scss
+++ b/scss/_larger.scss
@@ -3,8 +3,8 @@
 
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: math.div(3em, 4);
   vertical-align: -.0667em;
 }
 

--- a/scss/_larger.scss
+++ b/scss/_larger.scss
@@ -1,5 +1,6 @@
 // Icon Sizes
 // -------------------------
+@use 'sass:math';
 
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {

--- a/scss/_list.scss
+++ b/scss/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: $fa-li-width * math.div(5, 4);
   padding-left: 0;
 
   > li { position: relative; }

--- a/scss/_list.scss
+++ b/scss/_list.scss
@@ -1,5 +1,6 @@
 // List Icons
 // -------------------------
+@use 'sass:math';
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -9,7 +9,7 @@ $fa-version:           "5.15.3" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          math.div(20em, 16);
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,5 +1,6 @@
 // Variables
 // --------------------------
+@use 'sass:math';
 
 $fa-font-path:         "../webfonts" !default;
 $fa-font-size-base:    16px !default;


### PR DESCRIPTION
<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [X] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.


This PR fixes the outstanding deprecation of `/` division which will be removed in Dart Sass 2.0.0.
Building this package with webpack gives the following warning when using sass ^1.33.0:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(20em, 16)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
12 │ $fa-fw-width:          (20em / 16);
   │                         ^^^^^^^^^
   ╵
    node_modules/@fortawesome/fontawesome-free/scss/_variables.scss 12:25  @import
    node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss 5:9   @import
    style/fontawesome.scss 2:9                                             root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(4em, 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
6 │   font-size: (4em / 3);
  │               ^^^^^^^
  ╵
    node_modules/@fortawesome/fontawesome-free/scss/_larger.scss 6:15     @import
    node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss 8:9  @import
    style/fontawesome.scss 2:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(3em, 4)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
7 │   line-height: (3em / 4);
  │                 ^^^^^^^
  ╵
    node_modules/@fortawesome/fontawesome-free/scss/_larger.scss 7:17     @import
    node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss 8:9  @import
    style/fontawesome.scss 2:9                                            root stylesheet

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($fa-li-width * 5, 4)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
6 │   margin-left: $fa-li-width * 5/4;
  │                ^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@fortawesome/fontawesome-free/scss/_list.scss 6:16        @import
    node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss 10:9  @import
    style/fontawesome.scss 2:9                                             root stylesheet
```

The changes made in this PR conform to the sass deprecation guide:
https://sass-lang.com/documentation/breaking-changes/slash-div