### PR TITLE
Bath is not code

### DIFF
--- a/js-packages/@fortawesome/fontawesome-free/metadata/categories.yml
+++ b/js-packages/@fortawesome/fontawesome-free/metadata/categories.yml
@@ -478,7 +478,6 @@ code:
   icons:
     - archive
     - barcode
-    - bath
     - bug
     - code
     - code-branch

--- a/metadata/categories.yml
+++ b/metadata/categories.yml
@@ -478,7 +478,6 @@ code:
   icons:
     - archive
     - barcode
-    - bath
     - bug
     - code
     - code-branch


### PR DESCRIPTION
The "bath" icon was part of the "code" category which is obviously misplaced 🙂 

We always generate the icon list out of the category.json in [Fomantic-UI](https://fomantic-ui.com/elements/icon.html#code) and our users came across this here

https://twitter.com/LizzyReborn/status/1458308094258294786

![image](https://user-images.githubusercontent.com/18379884/141648772-814bf730-11a0-4e99-a8a1-f6c91a426e98.png)

 
I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
