### PR TITLE
Fix deprecation warnings with the division statements

### DIFF
--- a/scss/_larger.scss
+++ b/scss/_larger.scss
@@ -3,8 +3,8 @@
 
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: math.div(3em, 4);
   vertical-align: -.0667em;
 }
 

--- a/scss/_list.scss
+++ b/scss/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: math.div($fa-li-width * 5, 4);
   padding-left: 0;
 
   > li { position: relative; }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -9,7 +9,7 @@ $fa-version:           "5.15.4" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          math.div(20em, 16);
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 


### PR DESCRIPTION
The SCSS libraries are now reporting deprecation warnings as of the latest version of Font Awesome (5.15.4 as of this PR). The warnings are fixed in this particular PR and can be added manually to upstream if you folks desire.
<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
