### PR TITLE
Missing .fa-pull-left and .fa-pull-right added for Duotone (fad)

### DIFF
--- a/css/all.css
+++ b/css/all.css
@@ -90,6 +90,7 @@
 .fas.fa-pull-left,
 .far.fa-pull-left,
 .fal.fa-pull-left,
+.fad.fa-pull-left,
 .fab.fa-pull-left {
   margin-right: .3em; }
 
@@ -97,6 +98,7 @@
 .fas.fa-pull-right,
 .far.fa-pull-right,
 .fal.fa-pull-right,
+.fad.fa-pull-right,
 .fab.fa-pull-right {
   margin-left: .3em; }
 


### PR DESCRIPTION
Duotone icons were missing the "pull-left" and "pull-right" class.

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
