### PR TITLE
Mark css as having side effects in @fortawesome/fontawesome-svg-core

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/package.json
+++ b/js-packages/@fortawesome/fontawesome-svg-core/package.json
@@ -90,7 +90,8 @@
   },
   "sideEffects": [
     "./index.js",
-    "./index.es.js"
+    "./index.es.js",
+    "./styles.css"
   ],
   "scripts": {
     "postinstall": "node attribution.js"


### PR DESCRIPTION
We are manually importing the `styles.css` file in our project (to make our site work with our CSP policy as described in [the docs](https://fontawesome.com/v5.15/how-to-use/on-the-web/other-topics/security)) by including an `import '@fortawesome/fontawesome-svg-core/styles.css';` statement in our code. This was working perfectly before the 1.3 release of `@fortawesome/fontawesome-svg-core` but because of the `sideEffects` configuration, webpack is now treeshaking the CSS out of our build.

We have some other workarounds available to use but thought it might help other users to include it here?
