### PR TITLE
Thumbtack.js export name regression v5 -> v6

### DIFF
--- a/js-packages/@fortawesome/free-solid-svg-icons/faThumbtack.js
+++ b/js-packages/@fortawesome/free-solid-svg-icons/faThumbtack.js
@@ -12,7 +12,7 @@ exports.definition = {
     source.svgPathData
   ]};
 
-exports.faThumbTack = exports.definition;
+exports.faThumbtack = exports.definition;
 exports.prefix = source.prefix;
 exports.iconName = source.iconName;
 exports.width = source.width;


### PR DESCRIPTION
Comparing
https://unpkg.com/@fortawesome/free-solid-svg-icons@6.0.0/faThumbtack.js
and
https://unpkg.com/@fortawesome/free-solid-svg-icons@5.15.4/faThumbtack.js
one can see that the export name was changed from "Thumbtack" to "ThumbTack".

This unfortunately makes the icon not importable with the babel macro.

The correct export name is "Thumbtack" as in v5.

Same issue in the pro package, which I am looking at right now.

Cheers!

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
