### PR TITLE
Fixing an issue where if, `babelMacros` is not set in `package.json`

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/import.macro.js
+++ b/js-packages/@fortawesome/fontawesome-svg-core/import.macro.js
@@ -15,7 +15,7 @@ const styles = [
 ]
 
 function importer ({references, state, babel, source, config}) {
-  const license = (config !== undefined ? config.license : 'free')
+  const license = ((config !== undefined && config.license !== undefined) ? config.license : 'free')
 
   if (!['free', 'pro'].includes(license)) {
     throw new Error(


### PR DESCRIPTION
Fixing an issue where if, `babelMacros` is not set in `package.json`, then there is an error `"config license must be either 'free' or 'pro'"` because `config = {}`. 

We need to check for the `license` (`config.license`). See my [bug report here] (https://github.com/FortAwesome/Font-Awesome/issues/18711)

I understand that:

 I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but I understand that it will not be merged and I will not be listed as a contributor on this project.