### PR TITLE
Set type: module in package.json

### DIFF
--- a/js-packages/@fortawesome/fontawesome-common-types/package.json
+++ b/js-packages/@fortawesome/fontawesome-common-types/package.json
@@ -51,6 +51,7 @@
   "name": "@fortawesome/fontawesome-common-types",
   "license": "MIT",
   "types": "./index.d.ts",
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }

--- a/js-packages/@fortawesome/fontawesome-free/package.json
+++ b/js-packages/@fortawesome/fontawesome-free/package.json
@@ -52,6 +52,7 @@
   "main": "js/fontawesome.js",
   "style": "css/fontawesome.css",
   "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }

--- a/js-packages/@fortawesome/fontawesome-svg-core/package.json
+++ b/js-packages/@fortawesome/fontawesome-svg-core/package.json
@@ -92,6 +92,7 @@
     "./index.js",
     "./index.es.js"
   ],
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }

--- a/js-packages/@fortawesome/free-brands-svg-icons/package.json
+++ b/js-packages/@fortawesome/free-brands-svg-icons/package.json
@@ -75,6 +75,7 @@
     },
     "./*": "./*.js"
   },
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }

--- a/js-packages/@fortawesome/free-regular-svg-icons/package.json
+++ b/js-packages/@fortawesome/free-regular-svg-icons/package.json
@@ -75,6 +75,7 @@
     },
     "./*": "./*.js"
   },
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }

--- a/js-packages/@fortawesome/free-solid-svg-icons/package.json
+++ b/js-packages/@fortawesome/free-solid-svg-icons/package.json
@@ -75,6 +75,7 @@
     },
     "./*": "./*.js"
   },
+  "type": "module",
   "scripts": {
     "postinstall": "node attribution.js"
   }


### PR DESCRIPTION
Fixes #18514

I’ve tested (for `free-solig-svg-icons`) with sveltekit, building with the static adaptor —  this change fixes the compile time error, in node.
I’ve also tested with the auto adapter — this fixes the runtime (node) error.

Sadly my understanding of the javascript ecosystem is limited; I don’t know what consequences this change might have. According to [Modules: Packages | Node.js v17.5.0 Documentation](https://nodejs.org/api/packages.html#determining-module-system), though, the additional field is recommended.