### PR TITLE
Makes use of immutable classes names for icon mixins

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -46,7 +46,7 @@
 // and ::after elements in the duotone case.
 @mixin fa-icon-solid($fa-var) {
   @extend %fa-icon;
-  @extend .fa-solid;
+  @extend .fas;
 
   &::before {
     content: unquote("\"#{ $fa-var }\"");
@@ -55,7 +55,7 @@
 
 @mixin fa-icon-regular($fa-var) {
   @extend %fa-icon;
-  @extend .fa-regular;
+  @extend .far;
 
   &::before {
     content: unquote("\"#{ $fa-var }\"");
@@ -64,7 +64,7 @@
 
 @mixin fa-icon-brands($fa-var) {
   @extend %fa-icon;
-  @extend .fa-brands;
+  @extend .fab;
 
   &::before {
     content: unquote("\"#{ $fa-var }\"");


### PR DESCRIPTION
When using custom prefix the mixins gets broken.  See #18904 