### PR TITLE
Add Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/000_icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/000_icon_request.yml
@@ -1,0 +1,36 @@
+name: Icon request
+description: Suggest an icon to be included in Font Awesome
+labels: ["new icon"]
+title: "Icon request: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a new icon!
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Describe how this icon could be used.
+  - type: textarea
+    id: example
+    attributes:
+      label: Example image
+      description: Insert the example image here if necessary. A good example is a single color image which plays well at small sizes (16px)
+  - type: checkboxes
+    id: icon-request-checklist
+    attributes:
+      label: Icon request checklist
+      options:
+        - label: 'The title starts with "Icon request: " and is followed by the requested icon name'
+          required: true
+        - label: 'This icon does not represent a brand'
+          required: true
+        - label: 'This is a single icon or matched pair (Ex: `lock` / `unlock`)'
+          required: true
+        - label: The request is for a concrete object, or I've included an example image
+          required: true
+        - label: 'I have [searched for existing issues](https://github.com/FortAwesome/Font-Awesome/issues) and to the best of my knowledge this is not a duplicate'
+          required: true
+        - label: 'I have [understood how requests work](https://fontawesome.com/community/leaderboard/new#faqs)'
+          required: true

--- a/.github/ISSUE_TEMPLATE/001_brand_request.yml
+++ b/.github/ISSUE_TEMPLATE/001_brand_request.yml
@@ -1,0 +1,36 @@
+name: Brand request
+description: Suggest a brand to be included in Font Awesome
+labels: ["brand icon"]
+title: "Brand request: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a new brand!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please enter a brief description of this brand and why it is important to have it in the core of Font Awesome
+  - type: input
+    id: official-website
+    attributes:
+      label: Official website
+      description: Please provide the official website of this brand. The website must be in production and reachable from the public internet
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Brand guidelines
+      description: "Link to brand guidelines, if available (e.g.: https://about.twitter.com/en/who-we-are/brand-toolkit)"
+  - type: checkboxes
+    id: icon-request-checklist
+    attributes:
+      label: Icon request checklist
+      options:
+        - label: 'The title starts with "Brand request: ", is followed by the requested brand name'
+          required: true
+        - label: 'I have [searched for existing issues](https://github.com/FortAwesome/Font-Awesome/issues) and to the best of my knowledge this is not a duplicate'
+          required: true
+        - label: 'I have [understood how requests work](https://fontawesome.com/community/leaderboard/brands#faqs)'
+          required: true

--- a/.github/ISSUE_TEMPLATE/100_web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/100_web_bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report (Web - CSS - JS)
+description: Report a bug which occurs in a web application
+title: "Bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill up this bug report!
+
+        There are a lot of different ways of using Font Awesome. In order to help us
+        debugging, please provide as much information as you can.
+
+        A reduced reproducible test case would definitely help the process.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened? What are you seeing? How did you arrive here?
+    validations:
+      required: true
+  - type: input
+    id: reproducible-test-case
+    attributes:
+      label: Reproducible test case
+      description: Provide a URL to a reproducible use case. Use codepen.io, jsfiddle.net, jsbin.com, codesandbox.io, or whatever.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Add screenshots to help explain your problem
+  - type: input
+    id: version
+    attributes:
+      label: Font Awesome version
+      description: Provide the version of Font Awesome affected by this bug
+      placeholder: v6.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: serving
+    attributes:
+      label: Serving
+      multiple: true
+      options:
+        - Kit
+        - Font Awesome CDN
+        - Self-hosted
+        - Other (as specified in the bug description)
+    validations:
+      required: true
+  - type: dropdown
+    id: implementation
+    attributes:
+      label: Implementation
+      multiple: true
+      options:
+        - CSS
+        - SVG+JS
+        - SVG Sprites
+        - Other (as specified in the bug description)
+    validations:
+      required: true
+  - type: textarea
+    id: browser-operating-system
+    attributes:
+      label: Browser and Operating System
+      description: Provide information about the browser and operating system affected by this bug. [List of supported browsers](https://fontawesome.com/v6/docs/web/dig-deeper/browser-support)
+      placeholder: |
+        - Chrome 94 on Windows 10
+        - Firefox 92 on macOS
+    validations:
+      required: true
+  - type: checkboxes
+    id: web-bug-report-checklist
+    attributes:
+      label: Web bug report checklist
+      options:
+        - label: 'I have included a test case because my odds go _way_ up that the team can fix this when I do'
+        - label: 'I have [searched for existing issues](https://github.com/FortAwesome/Font-Awesome/issues) and to the best of my knowledge this is not a duplicate'
+          required: true

--- a/.github/ISSUE_TEMPLATE/101_other_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/101_other_bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report (Desktop / Native / Other)
+description: Report a bug which occurs outside of a web application
+title: "Bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill up this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened? What are you seeing? How did you arrive here?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Font Awesome version
+      description: Provide the version of Font Awesome affected by this bug
+      placeholder: v6.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: application-operating-system
+    attributes:
+      label: Application and Operating System
+      description: Provide information about the application and operating system affected by this bug
+      placeholder: |
+        - GIMP on Windows 10
+        - Adobe Photoshop on macOS
+    validations:
+      required: true
+  - type: checkboxes
+    id: web-bug-report-checklist
+    attributes:
+      label: Web bug report checklist
+      options:
+        - label: 'I have included a test case because my odds go _way_ up that the team can fix this when I do'
+        - label: 'I have [searched for existing issues](https://github.com/FortAwesome/Font-Awesome/issues) and to the best of my knowledge this is not a duplicate'
+          required: true

--- a/.github/ISSUE_TEMPLATE/200_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/200_feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an idea for Font Awesome
+title: "Feature request: "
+labels: ['feature']
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to request a new feature!
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is
+      placeholder: I'm always frustrated when...
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature description
+      description: A clear and concise description of what you want to happen
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here
+  - type: checkboxes
+    id: feature-request-checklist
+    attributes:
+      label: Feature request checklist
+      options:
+        - label: 'The title starts with "Feature request: " and is followed by the requested feature description'
+          required: true
+        - label: 'This is a single feature'
+          required: true
+        - label: 'I have [searched for existing issues](https://github.com/FortAwesome/Font-Awesome/issues) and to the best of my knowledge this is not a duplicate'
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Pro License Issue
+    url: https://fontawesome.com/#footer
+    about: Click on the "Support" link in the footer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--- WARNING Pull Requests made to this repository cannot be merged -->
+
+I understand that:
+
+- [ ] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
+  I understand that it will not be merged and I will not be listed as a contributor on this project.


### PR DESCRIPTION
Issue Forms are now supported on the desktop and mobile versions of
GitHub, and the mobile application links to the website to allow users
fill the form

Files have a numeric prefix to sort templates by priority, with icon
requests at the top

A special configuration is used to redirect users to the website when
the issue is related to the Pro License. License related issues should
not be addressed on a publicly accessible repository, because sensitive
information (like email address) are necessary

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms