### PR TITLE
[5.x] Fix breaking change slash as division in Dart Sass 2.0.0

### DIFF
--- a/scss/_larger.scss
+++ b/scss/_larger.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 // Icon Sizes
 // -------------------------
 
 // makes the font 33% larger relative to the icon container
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: math.div(3em, 4);
   vertical-align: -.0667em;
 }
 

--- a/scss/_list.scss
+++ b/scss/_list.scss
@@ -1,9 +1,11 @@
+@use "sass:math";
+
 // List Icons
 // -------------------------
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: math.div($fa-li-width * 5, 4);
   padding-left: 0;
 
   > li { position: relative; }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Variables
 // --------------------------
 
@@ -9,7 +11,7 @@ $fa-version:           "5.15.4" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          math.div(20em, 16);
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 


### PR DESCRIPTION
Updated due to deprecation warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0

Signed-off-by: mikejackson <mike@freightlink.co.uk>

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
