### PR TITLE
Fix #19423 by defaulting to 0 instead of none

### DIFF
--- a/less/_rotated-flipped.less
+++ b/less/_rotated-flipped.less
@@ -27,5 +27,5 @@
 }
 
 .@{fa-css-prefix}-rotate-by {
-  transform: rotate(~'var(--@{fa-css-prefix}-rotate-angle, none)');
+  transform: rotate(~'var(--@{fa-css-prefix}-rotate-angle, 0)');
 }

--- a/scss/_rotated-flipped.scss
+++ b/scss/_rotated-flipped.scss
@@ -27,5 +27,5 @@
 }
 
 .#{$fa-css-prefix}-rotate-by {
-  transform: rotate(var(--#{$fa-css-prefix}-rotate-angle, none));
+  transform: rotate(var(--#{$fa-css-prefix}-rotate-angle, 0));
 }


### PR DESCRIPTION
"transform: rotate(0);" makes sense as a default if no --fa-rotate-angle is defined.

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [X] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
