### PR TITLE
add `types` condition to the front of some `exports`

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/package.json
+++ b/js-packages/@fortawesome/fontawesome-svg-core/package.json
@@ -33,6 +33,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "module": "./index.mjs",
       "import": "./index.mjs",
       "require": "./index.js",
@@ -40,12 +41,14 @@
       "default": "./index.js"
     },
     "./index": {
+      "types": "./index.d.ts",
       "module": "./index.mjs",
       "import": "./index.mjs",
       "require": "./index.js",
       "default": "./index.js"
     },
     "./index.js": {
+      "types": "./index.d.ts",
       "module": "./index.mjs",
       "import": "./index.mjs",
       "require": "./index.js",

--- a/js-packages/@fortawesome/free-solid-svg-icons/package.json
+++ b/js-packages/@fortawesome/free-solid-svg-icons/package.json
@@ -33,16 +33,19 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js",
       "default": "./index.js"
     },
     "./index": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js",
       "default": "./index.js"
     },
     "./index.js": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js",
       "default": "./index.js"


### PR DESCRIPTION
I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.

---

I added `types` condition to the front of some `exports`. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here (and "💀 Failed to resolve" for some entries). You can check the reported errors [here](https://arethetypeswrong.github.io/?p=%40fortawesome%2Ffontawesome-svg-core%406.4.0) and [here](https://arethetypeswrong.github.io/?p=%40fortawesome%2Ffree-solid-svg-icons%406.4.0)