### PR TITLE
Fix validation error in _rotated-flipped.scss

### DIFF
--- a/scss/_rotated-flipped.scss
+++ b/scss/_rotated-flipped.scss
@@ -27,5 +27,5 @@
 }
 
 .#{$fa-css-prefix}-rotate-by {
-  transform: rotate(var(--#{$fa-css-prefix}-rotate-angle, none));
+  transform: rotate(var(--#{$fa-css-prefix}-rotate-angle, 0deg));
 }


### PR DESCRIPTION
HTML/CSS validators give an error due to the fact that "none" was used in a css transform, changing non to 0deg fixes this issue.

Example from the Nu html checker:

Error: CSS: transform: var(--fa-rotate-angle, none) is not a transform value.

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [X ] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
