### PR TITLE
fix trailing whitesaces and newlines at end of files

### DIFF
--- a/scss/_animated.scss
+++ b/scss/_animated.scss
@@ -150,4 +150,3 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
-

--- a/scss/_bordered-pulled.scss
+++ b/scss/_bordered-pulled.scss
@@ -9,12 +9,12 @@
   padding: var(--#{$fa-css-prefix}-border-padding, #{$fa-border-padding});
 }
 
-.#{$fa-css-prefix}-pull-left { 
+.#{$fa-css-prefix}-pull-left {
   float: left;
-  margin-right: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin}); 
+  margin-right: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin});
 }
 
-.#{$fa-css-prefix}-pull-right { 
+.#{$fa-css-prefix}-pull-right {
   float: right;
-  margin-left: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin}); 
+  margin-left: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin});
 }

--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -7,4 +7,3 @@ readers do not read off random characters that represent icons */
 @each $name, $icon in $fa-icons {
   .#{$fa-css-prefix}-#{$name}::before { content: unquote("\"#{ $icon }\""); }
 }
-

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -72,4 +72,3 @@
     content: unquote("\"#{ $fa-var }\"");
   }
 }
-

--- a/scss/_rotated-flipped.scss
+++ b/scss/_rotated-flipped.scss
@@ -22,7 +22,7 @@
 }
 
 .#{$fa-css-prefix}-flip-both,
-.#{$fa-css-prefix}-flip-horizontal.#{$fa-css-prefix}-flip-vertical { 
+.#{$fa-css-prefix}-flip-horizontal.#{$fa-css-prefix}-flip-vertical {
   transform: scale(-1, -1);
 }
 

--- a/scss/_shims.scss
+++ b/scss/_shims.scss
@@ -2039,4 +2039,3 @@
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-


### PR DESCRIPTION
Hello,

While integrating the latest version in my app I ran into scss linting issues, so here is the change that I'd like to see in your awesome library! :)

Fixes this:
![2023-10-19-190242_726x292_scrot](https://github.com/FortAwesome/Font-Awesome/assets/3043706/b1f18904-4fbf-4d09-b8cf-9e826aef67a0)



With best regards,
~Nico
