### PR TITLE
Make typing intent clearer

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
@@ -121,6 +121,6 @@ export interface DOM {
 }
 type IconDefinitionOrPack = IconDefinition | IconPack;
 export interface Library {
-  add(...definitions: IconDefinitionOrPack[] | IconDefinitionOrPack[][]): void;
+  add(...definitions: Array<IconDefinitionOrPack | IconDefinitionOrPack[]>): void;
   reset(): void;
 }


### PR DESCRIPTION
The current definition is hard to read due to the union type and with certain tooling not parsed correctly.

![image](https://github.com/user-attachments/assets/0f0fe4b8-62ff-45ff-b150-9767f33977bb)

The change proposed here would solve both.

----

An alternative would be the following, but personally I prefer the `Array<>` one.

```
add(...definitions: (IconDefinitionOrPack | IconDefinitionOrPack[])[]): void;
```

----

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
