### PR TITLE
Fix typescript typing for `parse.icon`

### DIFF
--- a/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-svg-core/index.d.ts
@@ -2,7 +2,7 @@ import {IconDefinition, IconLookup, IconName, IconFamily, IconPrefix, CssStyleCl
 export {IconDefinition, IconLookup, IconName, IconFamily, IconPrefix, CssStyleClass, IconStyle, IconPathData, IconPack} from '@fortawesome/fontawesome-common-types';
 export const dom: DOM;
 export const library: Library;
-export const parse: { transform(transformString: string): Transform, icon(parseIconString: string): IconLookup };
+export const parse: { transform(transformString: string): Transform, icon(parseIconString: string | { prefix: IconPrefix, iconName: IconName } | [string | IconPrefix, string | IconName]): IconLookup };
 export const config: Config;
 export function noAuto():void;
 export function findIconDefinition(iconLookup: IconLookup): IconDefinition;


### PR DESCRIPTION
Example how we can fix the typing for issue #20231

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
