### PR TITLE
Fix url to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 Font Awesome 6 is here! And with it a new location for the change log.
 
-Visit https://fontawesome.com/docs/changelog/.
+Visit https://fontawesome.com/v6/changelog.


### PR DESCRIPTION
The main changelog URL point to v7, causing the v6 branch to reference an incorrect changelog.

This commit updates the URL in the v6 branch to ensure it correctly points to the v6 changelog, maintaining accurate documentation for users referencing version 6.

<!--- WARNING Pull Requests made to this repository cannot be merged -->

I understand that:

- [x] I'm submitting this PR for reference only. It shows an example of what I'd like to see changed but
  I understand that it will not be merged and I will not be listed as a contributor on this project.
