### PR TITLE
Fix IconDefinition ligatures type to allow numbers and strings

### DIFF
--- a/js-packages/@fortawesome/fontawesome-common-types/index.d.ts
+++ b/js-packages/@fortawesome/fontawesome-common-types/index.d.ts
@@ -14,7 +14,7 @@ export interface IconDefinition extends IconLookup {
   icon: [
     number, // width
     number, // height
-    string[], // ligatures
+    (number | string)[], // ligatures
     string, // unicode
     IconPathData // svgPathData
   ];


### PR DESCRIPTION
### Problem
The `IconDefinition` type currently defines `ligatures` as `string[]`:
```ts
string[], // ligatures
