### PR TITLE
fix the typo of OLF to OFL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ commercial projects, open source projects, or really almost whatever you want.
 - Icons — CC BY 4.0 License
   - In the Font Awesome Free download, the CC BY 4.0 license applies to all icons packaged as .svg and .js files types.
 - Fonts — SIL OFL 1.1 License
-  - In the Font Awesome Free download, the SIL OLF license applies to all icons packaged as web and desktop font files.
+  - In the Font Awesome Free download, the SIL OFL license applies to all icons packaged as web and desktop font files.
 - Code — MIT License
   - In the Font Awesome Free download, the MIT license applies to all non-font and non-icon files.
 
-Attribution is required by MIT, SIL OLF, and CC BY licenses. Downloaded Font
+Attribution is required by MIT, SIL OFL, and CC BY licenses. Downloaded Font
 Awesome Free files already contain embedded comments with sufficient
 attribution, so you shouldn't need to do anything additional when using these
 files normally.


### PR DESCRIPTION
This PR addresses issue number #20151.
I have fixed the typo from "SL OLF" to "SL OFL" in the docs.