### PR TITLE
Moving Requests to Discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/brand-request.md
+++ b/.github/DISCUSSION_TEMPLATE/brand-request.md
@@ -1,0 +1,34 @@
+---
+title: "Brand request: <brand name>"
+labels: ["brand icon"]
+---
+
+## 👋 Thanks for suggesting a new brand!
+Brand icons only appear in the **Brands** pack, and they must represent real, active companies or products with publicly available branding.
+
+---
+
+## 🏷️ What brand are you requesting?
+Tell us the name of the brand and why it is important to have it in the core of Font Awesome.
+
+---
+
+## 🌐 Official website (required)
+Please provide the official website of this brand. The website must be in production and reachable from the public internet.
+
+---
+
+## 📘 Brand assets or guidelines (optional)
+Links to brand guidelines, press kits, logo assets, or other references.
+
+---
+
+## 🔍 Request checklist
+- [ ] This is a real, established brand or product  
+- [ ] The brand is not already available in Font Awesome  
+- [ ] I’ve searched existing brand requests to avoid duplicates  
+- [ ] I understand how brand requests work and the criteria for acceptance  
+
+---
+
+Feel free to add any extra notes or context below!

--- a/.github/DISCUSSION_TEMPLATE/config.yml
+++ b/.github/DISCUSSION_TEMPLATE/config.yml
@@ -1,0 +1,23 @@
+# .github/DISCUSSION_TEMPLATE/config.yml
+
+categories:
+  - id: icon-requests
+    title: "✨ Icon Requests"
+    description: "Request new icons and vote on what we should design next."
+    labels: ["icon-request"]
+    templates:
+      - icon-request.md
+
+  - id: brand-requests
+    title: "🏢 Brand Requests"
+    description: "Request new brand or product logos for the Brands pack."
+    labels: ["brand icon"]
+    templates:
+      - brand-request.md
+
+  - id: icon-wizard-requests
+    title: "🧙 Icon Wizard Requests"
+    description: "Request new modifiers to add to the Icon Wizard."
+    labels: ["icon wizard modifier"]
+    templates:
+      - icon-wizard-request.md

--- a/.github/DISCUSSION_TEMPLATE/icon-request.md
+++ b/.github/DISCUSSION_TEMPLATE/icon-request.md
@@ -1,0 +1,51 @@
+---
+title: "Icon request: <name of icon>"
+labels: ["icon-request"]
+---
+
+## 👋 Thanks for suggesting a new icon!
+Your ideas help shape what we design next. A clear, thoughtful request makes it easier for the community to vote on and for our team to evaluate.
+
+---
+
+## 🧩 What icon are you requesting?
+Describe the icon and the concept it should represent.
+
+---
+
+## 💡 Where would this icon be used?
+Tell us the scenario, UI, or workflow where this icon appears.
+
+---
+
+## 🖼️ Visual references (optional but very helpful)
+Paste example images, sketches, screenshots, or links here. Simple, single-color images are best.
+
+---
+
+## 🎨 Preferred pack(s) (optional)
+Which Font Awesome pack(s) could this icon appear in?
+
+### Core Icon Packs
+- [ ] Classic, Duotone, Sharp, Sharp Duotone
+
+### Pro+ Icon Packs
+- [ ] Chisel 
+- [ ] Etch 
+- [ ] Jelly  
+- [ ] Notdog  
+- [ ] Slab  
+- [ ] Thumbprint  
+- [ ] Utility  
+- [ ] Whiteboard  
+
+---
+
+## ✅ Request checklist
+Help us keep things organized by confirming the following:
+
+- [ ] This request is **not** for a brand or logo (those follow a different request flow)  
+- [ ] This request is for a **single, clear concept** (or a matched pair like `lock` / `unlock`)  
+- [ ] I’ve included references *or* the concept is easy to visualize  
+- [ ] I searched existing Discussions/Issues to avoid duplicates  
+- [ ] I understand how icon requests work and what makes one more likely to be accepted

--- a/.github/DISCUSSION_TEMPLATE/icon-wizard-request.md
+++ b/.github/DISCUSSION_TEMPLATE/icon-wizard-request.md
@@ -1,0 +1,22 @@
+---
+title: "Wizard request: <modifier name>"
+labels: ["icon wizard modifier"]
+---
+
+## 🧙‍♂️ What modifier are you requesting?
+Describe the modifier you’d like to add and what it should represent.
+
+---
+
+## 💡 How would you use this modifier?
+Tell us how you’d combine it with core icons and where it would show up in a UI.
+
+*Ex: `folder + file` for file-related folders, `user + warning` for risky accounts, etc.*
+
+---
+
+## ✅ Request checklist
+- [ ] This is a generic symbol, not a brand or logo  
+- [ ] This concept would work as a **small corner/badge modifier**, not a full-size icon  
+- [ ] I’ve checked existing Icon Wizard modifiers and didn’t find this idea  
+- [ ] This is a single, clear modifier concept


### PR DESCRIPTION
In order to lessen the signal-to-noise ratio in our Icon Requests, I think we should move new requests to discussions, instead of issues. This PR sets up some initial templates for us to use. The concept itself is still WIP, so we'll likely make updates/changes as we go.