### PR TITLE
Modify bug report template for versioning and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/101_other_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/101_other_bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report (Desktop / Native / Other)
 description: Report a bug which occurs outside of a web application
-title: "Bug: "
-labels: ["bug", "needs-triage"]
+labels: ["needs-triage"]
+type: bug
 body:
   - type: markdown
     attributes:
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Font Awesome version
       description: Provide the version of Font Awesome affected by this bug
-      placeholder: v6.0.0
+      placeholder: v7.1.0
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Removed "Bug:" from auto-fill for titles, to reduce visual noise of issue tracker.

Swapped "bug" label for "Bug" type.