### PR TITLE
Simplifying icon request titles

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/icon-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/icon-requests.yml
@@ -1,4 +1,4 @@
-title: "Icon Request: "
+title: "[Icon Name] Icon"
 labels:
   - "icon request"
   - "new icon"


### PR DESCRIPTION
We already have an "icon request" label for these, and they are placed in the "icon request" discussion category. By also having "icon request" in the title of the discussion, it started to feel too noisy and redundant.