### PR TITLE
fix: add setup-icon() mixin for assigning icons to ::before and ::aft…

### DIFF
--- a/scss/brands.scss
+++ b/scss/brands.scss
@@ -33,11 +33,18 @@
   }
 }
 
-// convenience mixin for declaring pseudo-elements by CSS variable,
-// including all style-specific font properties and ::before elements.
-@mixin icon($var) {
+// sets up icon font properties (family, style, rendering) without assigning
+// an icon to ::before — useful when you need to assign content to both
+// ::before and ::after, or want to set the icon separately.
+@mixin setup-icon() {
   @include m.fa-icon(Font Awesome 7 Brands);
   @extend .#{v.$css-prefix}-brands;
+}
+
+// convenience mixin for declaring pseudo-elements by CSS variable,
+// including all style-specific font properties and ::before content.
+@mixin icon($var) {
+  @include setup-icon();
 
   &::before {
     content: string.unquote("\"#{ $var }\"");

--- a/scss/regular.scss
+++ b/scss/regular.scss
@@ -38,12 +38,19 @@
   --#{v.$css-prefix}-style: 400;
 }
 
-// convenience mixin for declaring pseudo-elements by CSS variable,
-// including all style-specific font properties and ::before elements.
-@mixin icon($var) {
+// sets up icon font properties (family, style, rendering) without assigning
+// an icon to ::before — useful when you need to assign content to both
+// ::before and ::after, or want to set the icon separately.
+@mixin setup-icon() {
   @include m.fa-icon(Font Awesome 7 Free);
   @extend .#{v.$css-prefix}-regular;
   @extend .#{v.$css-prefix}-classic;
+}
+
+// convenience mixin for declaring pseudo-elements by CSS variable,
+// including all style-specific font properties and ::before content.
+@mixin icon($var) {
+  @include setup-icon();
 
   &::before {
     content: string.unquote("\"#{ $var }\"");

--- a/scss/solid.scss
+++ b/scss/solid.scss
@@ -38,12 +38,19 @@
   --#{v.$css-prefix}-style: 900;
 }
 
-// convenience mixin for declaring pseudo-elements by CSS variable,
-// including all style-specific font properties and ::before elements.
-@mixin icon($var) {
+// sets up icon font properties (family, style, rendering) without assigning
+// an icon to ::before — useful when you need to assign content to both
+// ::before and ::after, or want to set the icon separately.
+@mixin setup-icon() {
   @include m.fa-icon(Font Awesome 7 Free);
   @extend .#{v.$css-prefix}-solid;
   @extend .#{v.$css-prefix}-classic;
+}
+
+// convenience mixin for declaring pseudo-elements by CSS variable,
+// including all style-specific font properties and ::before content.
+@mixin icon($var) {
+  @include setup-icon();
 
   &::before {
     content: string.unquote("\"#{ $var }\"");


### PR DESCRIPTION
What does this PR do?
Adds a setup-icon() mixin to solid.scss, regular.scss, and brands.scss that sets up all icon font properties (family, style, smoothing, rendering) without assigning content to ::before.
Why is this needed?
The existing icon($var) mixin always assigns the icon to ::before, making it impossible to apply FA icons to both ::before and ::after on the same element. With setup-icon(), users can set up the font once and assign content to either pseudo-element independently:
%fa-icon-base {
  &::before, &::after {
    @include fa-solid.setup-icon();
  }
}

.disclaimer.warning {
  @extend %fa-icon-base;
  &::before { content: fa.fa-content(fa.$var-triangle-exclamation); }
  &::after  { content: fa.fa-content(fa.$var-triangle-exclamation); }
}
icon($var) is refactored to call setup-icon() internally — no behavior change, no breaking changes.
Closes #21562